### PR TITLE
feat: implement `AutoCloseable` for AS400 objects

### DIFF
--- a/src/main/java/com/ibm/as400/access/AS400.java
+++ b/src/main/java/com/ibm/as400/access/AS400.java
@@ -55,7 +55,7 @@ import com.ibm.as400.security.auth.ProfileTokenProvider;
  *    system.connectService(AS400.FILE);        // This does not cause a prompt.
  </pre>
  **/
-public class AS400 implements Serializable
+public class AS400 implements Serializable, AutoCloseable
 {
     private static final String CLASSNAME = "com.ibm.as400.access.AS400";
     static boolean jdk14 = false;
@@ -5079,5 +5079,9 @@ public class AS400 implements Serializable
 
         return pwdlvl;
     }
-    
+
+    @Override
+    public void close() throws Exception {
+        disconnectAllServices();
+    }
 }


### PR DESCRIPTION
Allows for `AS400` objects to be used with try-with-resources blocks, causing all services to be disconnected when the object is no longer in use

For instance:

```java
try(AS400 as400 = new AS400("systemname", "userid", "pw".toCharArray())) {
    IFSFile file = new IFSFile(as400, "/my/path");
    // etc etc
}
```