### PR TITLE
Throw Error When Response Fails

### DIFF
--- a/src/main/java/com/ibm/as400/access/AS400ImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/AS400ImplRemote.java
@@ -699,9 +699,10 @@ public class AS400ImplRemote implements AS400Impl {
         rc = ((IFSCreateUserHandleRep) ds).getReturnCode();
         if (rc != IFSReturnCodeRep.SUCCESS) {
           Trace.log(Trace.ERROR, "IFSCreateUserHandleRep return code", rc);
+          throw new ExtendedIOException(rc);
         }
         UserHandle = ((IFSCreateUserHandleRep) ds).getHandle();
-
+        
       } else if (ds instanceof IFSReturnCodeRep) {
         rc = ((IFSReturnCodeRep) ds).getReturnCode();
         if (rc != IFSReturnCodeRep.SUCCESS) {


### PR DESCRIPTION
When response indicates failure, throw an exception. Failing here will fail with the proper message to the client, instead of failing on a subsequent request with a bad user handle ID.