### PR TITLE
remove Boolean constructor usages

### DIFF
--- a/src/main/java/com/ibm/as400/access/AS400.java
+++ b/src/main/java/com/ibm/as400/access/AS400.java
@@ -4018,8 +4018,8 @@ public class AS400 implements Serializable, AutoCloseable
         }
         else
         {
-            Boolean oldValue = new Boolean(guiAvailable_);
-            Boolean newValue = new Boolean(guiAvailable);
+            Boolean oldValue = Boolean.valueOf(guiAvailable_);
+            Boolean newValue = Boolean.valueOf(guiAvailable);
 
             if (vetoableChangeListeners_ != null)
             {
@@ -4465,8 +4465,8 @@ public class AS400 implements Serializable, AutoCloseable
         }
         else
         {
-            Boolean oldValue = new Boolean(threadUsed_);
-            Boolean newValue = new Boolean(useThreads);
+            Boolean oldValue = Boolean.valueOf(threadUsed_);
+            Boolean newValue = Boolean.valueOf(useThreads);
 
             if (vetoableChangeListeners_ != null)
             {
@@ -4495,8 +4495,8 @@ public class AS400 implements Serializable, AutoCloseable
         }
         else
         {
-            Boolean oldValue = new Boolean(useDefaultUser_);
-            Boolean newValue = new Boolean(useDefaultUser);
+            Boolean oldValue = Boolean.valueOf(useDefaultUser_);
+            Boolean newValue = Boolean.valueOf(useDefaultUser);
 
             if (vetoableChangeListeners_ != null)
             {
@@ -4526,8 +4526,8 @@ public class AS400 implements Serializable, AutoCloseable
         }
         else
         {
-            Boolean oldValue = new Boolean(usePasswordCache_);
-            Boolean newValue = new Boolean(usePasswordCache);
+            Boolean oldValue = Boolean.valueOf(usePasswordCache_);
+            Boolean newValue = Boolean.valueOf(usePasswordCache);
 
             if (vetoableChangeListeners_ != null)
             {

--- a/src/main/java/com/ibm/as400/access/AS400File.java
+++ b/src/main/java/com/ibm/as400/access/AS400File.java
@@ -437,9 +437,9 @@ abstract public class AS400File implements Serializable, AutoCloseable
                                    new Object[] { system_.getImpl(), //@B5C
                                    name_,
                                    recordFormat_,
-                                   new Boolean(readNoUpdate_), //@B5A
-                                   new Boolean(this instanceof KeyedFile),
-                                   new Boolean(ssp_) });
+                                   Boolean.valueOf(readNoUpdate_), //@B5A
+                                   Boolean.valueOf(this instanceof KeyedFile),
+                                   Boolean.valueOf(ssp_) });
 
             //      impl_.doItNoExceptions("setSystem", new Class[] { AS400.class }, new Object[] { system_ }); //@B0A
             //      impl_.doItNoExceptions("setPath", new Class[] { String.class }, new Object[] { name_ }); //@B0A
@@ -447,7 +447,7 @@ abstract public class AS400File implements Serializable, AutoCloseable
 
             // The following line is provided so the remote class knows
             // if it is a keyed file or a sequential file.
-            //      impl_.doItNoExceptions("setIsKeyed", new Class[] { Boolean.TYPE }, new Object[] { new Boolean(this instanceof KeyedFile) }); //@B0A
+            //      impl_.doItNoExceptions("setIsKeyed", new Class[] { Boolean.TYPE }, new Object[] { Boolean.valueOf(this instanceof KeyedFile) }); //@B0A
         }
     }
 
@@ -867,7 +867,7 @@ abstract public class AS400File implements Serializable, AutoCloseable
                    RecordFormat.class, String.class, String.class,
                    String.class, String.class, Boolean.TYPE,
                    String.class, String.class },
-                   new Object[] { recordFormat, altSeq, ccsid, order, ref, new Boolean(unique), //@B0C
+                   new Object[] { recordFormat, altSeq, ccsid, order, ref, Boolean.valueOf(unique), //@B0C
                    format, text });
 
         // Create the file based on the newly create DDS source file
@@ -2256,7 +2256,7 @@ abstract public class AS400File implements Serializable, AutoCloseable
         if (impl_ != null) //@B5A
         {
             impl_.doItNoExceptions("setReadNoUpdate", new Class[] { Boolean.TYPE },
-            new Object[] { new Boolean(readNoUpdate) }); //@B0C
+            new Object[] { Boolean.valueOf(readNoUpdate) }); //@B0C
         }
     }
 
@@ -2397,7 +2397,7 @@ abstract public class AS400File implements Serializable, AutoCloseable
       if (impl_ != null)
       {
         impl_.doItNoExceptions("setSSPFile", new Class[] { Boolean.TYPE },
-        new Object[] { new Boolean(treatAsSSP) });
+        new Object[] { Boolean.valueOf(treatAsSSP) });
       }
     }
 

--- a/src/main/java/com/ibm/as400/access/AS400FileImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/AS400FileImplProxy.java
@@ -179,7 +179,7 @@ class AS400FileImplProxy extends AbstractProxyImpl implements AS400FileImpl
     {
       return (String[])connection_.callMethod(pxId_, "openFile2",
                                                     new Class[] { Integer.TYPE, Integer.TYPE, Integer.TYPE, Boolean.TYPE },
-                                                    new Object[] { new Integer(openType), new Integer(bf), new Integer(level), new Boolean(access) }).getReturnValue();
+                                                    new Object[] { new Integer(openType), new Integer(bf), new Integer(level), Boolean.valueOf(access) }).getReturnValue();
     }      
     catch(InvocationTargetException e)
     {

--- a/src/main/java/com/ibm/as400/access/AS400ImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/AS400ImplProxy.java
@@ -62,7 +62,7 @@ class AS400ImplProxy extends AbstractProxyImpl implements AS400Impl
     {
         try
         {
-            return (SignonInfo)connection_.callMethod(pxId_, "changePassword", new Class[] { String.class, Boolean.TYPE, String.class, byte[].class, byte[].class }, new Object[] { systemName, new Boolean(systemNameLocal), userId, oldBytes, newBytes }).getReturnValue();
+            return (SignonInfo)connection_.callMethod(pxId_, "changePassword", new Class[] { String.class, Boolean.TYPE, String.class, byte[].class, byte[].class }, new Object[] { systemName, Boolean.valueOf(systemNameLocal), userId, oldBytes, newBytes }).getReturnValue();
         }
         catch (InvocationTargetException e)
         {
@@ -81,7 +81,7 @@ class AS400ImplProxy extends AbstractProxyImpl implements AS400Impl
         {
             connection_.callMethod(pxId_, "connect", 
                 new Class[] { Integer.TYPE, Integer.TYPE, Boolean.TYPE }, 
-                new Object[] { new Integer(service), new Integer(overridePort), new Boolean(skipSignonServer) });
+                new Object[] { new Integer(service), new Integer(overridePort), Boolean.valueOf(skipSignonServer) });
         }
         catch (InvocationTargetException e)
         {
@@ -109,7 +109,7 @@ class AS400ImplProxy extends AbstractProxyImpl implements AS400Impl
             return (Socket)connection_.callMethod(pxId_, 
                 "connectToPort", 
                 new Class[] { Integer.TYPE, Boolean.TYPE }, 
-                new Object[] { new Integer(port), new Boolean(forceNonLocalhost) }).getReturnValue();
+                new Object[] { new Integer(port), Boolean.valueOf(forceNonLocalhost) }).getReturnValue();
         }
         catch (InvocationTargetException e)
         {
@@ -320,7 +320,7 @@ class AS400ImplProxy extends AbstractProxyImpl implements AS400Impl
     {
         try
         {
-            connection_.callMethod(pxId_, "setState", new Class[] { SSLOptions.class, Boolean.TYPE, Boolean.TYPE, Integer.TYPE, String.class, SocketProperties.class, String.class, Boolean.TYPE, Boolean.TYPE, Boolean.TYPE }, new Object[] { useSSLConnection, new Boolean(canUseNativeOptimization), new Boolean(threadUsed), new Integer(ccsid), nlv, socketProperties, ddmRDB, new Boolean(mustUseNetSockets), new Boolean(mustUseSuppliedProfile), new Boolean(mustAddLanguageLibrary) } );
+            connection_.callMethod(pxId_, "setState", new Class[] { SSLOptions.class, Boolean.TYPE, Boolean.TYPE, Integer.TYPE, String.class, SocketProperties.class, String.class, Boolean.TYPE, Boolean.TYPE, Boolean.TYPE }, new Object[] { useSSLConnection, Boolean.valueOf(canUseNativeOptimization), Boolean.valueOf(threadUsed), new Integer(ccsid), nlv, socketProperties, ddmRDB, Boolean.valueOf(mustUseNetSockets), Boolean.valueOf(mustUseSuppliedProfile), Boolean.valueOf(mustAddLanguageLibrary) } );
         }
         catch (InvocationTargetException e)
         {
@@ -333,7 +333,7 @@ class AS400ImplProxy extends AbstractProxyImpl implements AS400Impl
     {
         try
         {
-            return (SignonInfo)connection_.callMethod(pxId_, "signon", new Class[] { String.class, Boolean.TYPE, String.class, CredentialVault.class, String.class }, new Object[] { systemName, new Boolean(systemNameLocal), userId, vault, gssName }).getReturnValue();
+            return (SignonInfo)connection_.callMethod(pxId_, "signon", new Class[] { String.class, Boolean.TYPE, String.class, CredentialVault.class, String.class }, new Object[] { systemName, Boolean.valueOf(systemNameLocal), userId, vault, gssName }).getReturnValue();
         }
         catch (InvocationTargetException e)
         {
@@ -346,7 +346,7 @@ class AS400ImplProxy extends AbstractProxyImpl implements AS400Impl
     {
         try
         {
-            return (SignonInfo)connection_.callMethod(pxId_, "skipSignon", new Class[] { String.class, Boolean.TYPE, String.class, CredentialVault.class, String.class }, new Object[] { systemName, new Boolean(systemNameLocal), userId, vault, gssName }).getReturnValue();
+            return (SignonInfo)connection_.callMethod(pxId_, "skipSignon", new Class[] { String.class, Boolean.TYPE, String.class, CredentialVault.class, String.class }, new Object[] { systemName, Boolean.valueOf(systemNameLocal), userId, vault, gssName }).getReturnValue();
         }
         catch (InvocationTargetException e)
         {

--- a/src/main/java/com/ibm/as400/access/AS400JDBCArray.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCArray.java
@@ -2081,7 +2081,7 @@ public class AS400JDBCArray implements Array, Serializable {
         boolean[] inBooleanArray = (boolean[]) inArray;
         Boolean[] booleanArray = new Boolean[inBooleanArray.length];
         for (int i = 0; i < inBooleanArray.length; i++) {
-            booleanArray[i] = new Boolean(inBooleanArray[i]); 
+            booleanArray[i] = Boolean.valueOf(inBooleanArray[i]); 
         }
         data_ = booleanArray;
 
@@ -2097,7 +2097,7 @@ public class AS400JDBCArray implements Array, Serializable {
         int[] inIntegerArray = (int[]) inArray;
         Boolean[] booleanArray = new Boolean[inIntegerArray.length];
         for (int i = 0; i < inIntegerArray.length; i++) {
-            booleanArray[i] = new Boolean(SQLBoolean.getBoolean(this, inIntegerArray[i])); 
+            booleanArray[i] = Boolean.valueOf(SQLBoolean.getBoolean(this, inIntegerArray[i])); 
         }
         data_ = booleanArray;
       } else if ("java.math.BigDecimal".equals(arrayType)) {

--- a/src/main/java/com/ibm/as400/access/AS400JDBCArrayResultSet.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCArrayResultSet.java
@@ -4272,7 +4272,7 @@ implements ResultSet
          if (b == false && wasNull()) { 
            return null;  
          } else { 
-           return new Boolean (b);
+           return Boolean.valueOf(b);
          }
          
        } else if (type == java.sql.Date.class){

--- a/src/main/java/com/ibm/as400/access/AS400JDBCCallableStatement.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCCallableStatement.java
@@ -4496,7 +4496,7 @@ implements CallableStatement
         if (b == false && wasNull()) { 
           return null;  
         } else { 
-          return new Boolean (b);
+          return Boolean.valueOf(b);
         }
         
       } else if (type == java.sql.Date.class){

--- a/src/main/java/com/ibm/as400/access/AS400JDBCDataSource.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCDataSource.java
@@ -2191,8 +2191,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
       public void setAutoCommit(boolean value)
       {
           String property = "autoCommit";
-          Boolean oldValue = new Boolean(isAutoCommit());
-          Boolean newValue = new Boolean(value);
+          Boolean oldValue = Boolean.valueOf(isAutoCommit());
+          Boolean newValue = Boolean.valueOf(value);
 
           if (value)
               properties_.setString(JDProperties.AUTO_COMMIT, TRUE_);
@@ -2214,8 +2214,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
      public void setAutocommitException(boolean value)
      {
          String property = "autocommitException";
-         Boolean oldValue = new Boolean(isAutocommitException());
-         Boolean newValue = new Boolean(value);
+         Boolean oldValue = Boolean.valueOf(isAutocommitException());
+         Boolean newValue = Boolean.valueOf(value);
 
          if (value)
              properties_.setString(JDProperties.AUTOCOMMIT_EXCEPTION, TRUE_);
@@ -2237,8 +2237,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setTrueAutoCommit(boolean value)
     {
         String property = "trueAutoCommit";
-        Boolean oldValue = new Boolean(isTrueAutoCommit());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isTrueAutoCommit());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.TRUE_AUTO_COMMIT, TRUE_); //@true
@@ -2338,8 +2338,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setBidiImplicitReordering(boolean value)
     {
         String property = "bidiImplicitReordering";
-        Boolean oldValue = new Boolean(isBidiImplicitReordering());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isBidiImplicitReordering());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.BIDI_IMPLICIT_REORDERING, TRUE_);
@@ -2361,8 +2361,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setBidiNumericOrdering(boolean value)
     {
         String property = "bidiNumericOrdering";
-        Boolean oldValue = new Boolean(isBidiNumericOrdering());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isBidiNumericOrdering());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.BIDI_NUMERIC_ORDERING, TRUE_);
@@ -2383,8 +2383,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setBigDecimal(boolean value)
     {
         String property = "bigDecimal";
-        Boolean oldValue = new Boolean(isBigDecimal());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isBigDecimal());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.BIG_DECIMAL, TRUE_);
@@ -2585,8 +2585,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setCursorHold(boolean cursorHold)
     {
         String property = "cursorHold";
-        Boolean oldHold = new Boolean(isCursorHold());
-        Boolean newHold = new Boolean(cursorHold);
+        Boolean oldHold = Boolean.valueOf(isCursorHold());
+        Boolean newHold = Boolean.valueOf(cursorHold);
 
         if (cursorHold)
             properties_.setString(JDProperties.CURSOR_HOLD, TRUE_);
@@ -2646,8 +2646,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setDataCompression(boolean compression)
     {
-        Boolean oldCompression = new Boolean(isDataCompression());
-        Boolean newCompression = new Boolean(compression);
+        Boolean oldCompression = Boolean.valueOf(isDataCompression());
+        Boolean newCompression = Boolean.valueOf(compression);
 
         if (compression)
             properties_.setString(JDProperties.DATA_COMPRESSION, TRUE_);
@@ -2687,8 +2687,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setDataTruncation(boolean truncation)
     {
-        Boolean oldTruncation = new Boolean(isDataTruncation());
-        Boolean newTruncation = new Boolean(truncation);
+        Boolean oldTruncation = Boolean.valueOf(isDataTruncation());
+        Boolean newTruncation = Boolean.valueOf(truncation);
 
         if (truncation)
             properties_.setString(JDProperties.DATA_TRUNCATION, TRUE_);
@@ -2968,8 +2968,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setExtendedDynamic(boolean extendedDynamic)
     {
-        Boolean oldValue = new Boolean(isExtendedDynamic());
-        Boolean newValue = new Boolean(extendedDynamic);
+        Boolean oldValue = Boolean.valueOf(isExtendedDynamic());
+        Boolean newValue = Boolean.valueOf(extendedDynamic);
 
         if (extendedDynamic)
             properties_.setString(JDProperties.EXTENDED_DYNAMIC, TRUE_);
@@ -3006,8 +3006,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setExtendedMetaData(boolean extendedMetaData)
     {
-        Boolean oldValue = new Boolean(isExtendedMetaData());
-        Boolean newValue = new Boolean(extendedMetaData);
+        Boolean oldValue = Boolean.valueOf(isExtendedMetaData());
+        Boolean newValue = Boolean.valueOf(extendedMetaData);
 
         if (extendedMetaData)
             properties_.setString(JDProperties.EXTENDED_METADATA, TRUE_);
@@ -3066,8 +3066,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setFullOpen(boolean fullOpen)
     {
-        Boolean oldValue = new Boolean(isFullOpen());
-        Boolean newValue = new Boolean(fullOpen);
+        Boolean oldValue = Boolean.valueOf(isFullOpen());
+        Boolean newValue = Boolean.valueOf(fullOpen);
 
         if (fullOpen)
             properties_.setString(JDProperties.FULL_OPEN, TRUE_);
@@ -3089,8 +3089,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setHoldInputLocators(boolean value)
     {
         String property = "holdInputLocators";
-        Boolean oldValue = new Boolean(isHoldInputLocators());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isHoldInputLocators());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.HOLD_LOCATORS, TRUE_);
@@ -3113,8 +3113,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setHoldStatements(boolean value)
     {
         String property = "holdStatements";
-        Boolean oldValue = new Boolean(isHoldStatements());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isHoldStatements());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.HOLD_STATEMENTS, TRUE_);
@@ -3136,8 +3136,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setJvm16Synchronize(boolean value)
     {
         String property = "jvm16 synchronize";
-        Boolean oldValue = new Boolean(isJvm16Synchronize());
-        Boolean newValue = new Boolean(value);
+        Boolean oldValue = Boolean.valueOf(isJvm16Synchronize());
+        Boolean newValue = Boolean.valueOf(value);
 
         if (value)
             properties_.setString(JDProperties.JVM16_SYNCHRONIZE, TRUE_);
@@ -3158,8 +3158,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setLazyClose(boolean lazyClose)
     {
-        Boolean oldValue = new Boolean(isLazyClose());
-        Boolean newValue = new Boolean(lazyClose);
+        Boolean oldValue = Boolean.valueOf(isLazyClose());
+        Boolean newValue = Boolean.valueOf(lazyClose);
 
         if (lazyClose)
             properties_.setString(JDProperties.LAZY_CLOSE, TRUE_);
@@ -3376,8 +3376,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setPackageAdd(boolean add)
     {
-        Boolean oldValue = new Boolean(isPackageAdd());
-        Boolean newValue = new Boolean(add);
+        Boolean oldValue = Boolean.valueOf(isPackageAdd());
+        Boolean newValue = Boolean.valueOf(add);
 
         if (add)
             properties_.setString(JDProperties.PACKAGE_ADD, TRUE_);
@@ -3399,8 +3399,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setPackageCache(boolean cache)
     {
-        Boolean oldValue = new Boolean(isPackageCache());
-        Boolean newValue = new Boolean(cache);
+        Boolean oldValue = Boolean.valueOf(isPackageCache());
+        Boolean newValue = Boolean.valueOf(cache);
 
         if (cache)
             properties_.setString(JDProperties.PACKAGE_CACHE, TRUE_);
@@ -3430,8 +3430,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
         //@C6D threshold where package clearing is needed is now handled
         //@C6D automatically by the database.
 
-        //@C6D Boolean oldValue = new Boolean(isPackageClear());
-        //@C6D Boolean newValue = new Boolean(clear);
+        //@C6D Boolean oldValue = Boolean.valueOf(isPackageClear());
+        //@C6D Boolean newValue = Boolean.valueOf(clear);
 
         //@C6D String value = null;
         //@C6D if (clear)
@@ -3547,8 +3547,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setPrefetch(boolean prefetch)
     {
-        Boolean oldValue = new Boolean(isPrefetch());
-        Boolean newValue = new Boolean(prefetch);
+        Boolean oldValue = Boolean.valueOf(isPrefetch());
+        Boolean newValue = Boolean.valueOf(prefetch);
 
         if (prefetch)
             properties_.setString(JDProperties.PREFETCH, TRUE_);
@@ -3571,8 +3571,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setPrompt(boolean prompt)
     {
-        Boolean oldValue = new Boolean(isPrompt());
-        Boolean newValue = new Boolean(prompt);
+        Boolean oldValue = Boolean.valueOf(isPrompt());
+        Boolean newValue = Boolean.valueOf(prompt);
 
         if (prompt)
             properties_.setString(JDProperties.PROMPT, TRUE_);
@@ -3846,8 +3846,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setRollbackCursorHold(boolean cursorHold)
     {
         String property = "rollbackCursorHold";
-        Boolean oldHold = new Boolean(isRollbackCursorHold());
-        Boolean newHold = new Boolean(cursorHold);
+        Boolean oldHold = Boolean.valueOf(isRollbackCursorHold());
+        Boolean newHold = Boolean.valueOf(cursorHold);
 
         if (cursorHold)
             properties_.setString(JDProperties.ROLLBACK_CURSOR_HOLD, TRUE_);
@@ -3906,8 +3906,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setSecure(boolean secure)
     {
-        Boolean oldValue = new Boolean(isSecure());
-        Boolean newValue = new Boolean(secure);
+        Boolean oldValue = Boolean.valueOf(isSecure());
+        Boolean newValue = Boolean.valueOf(secure);
 
         //Do not allow user to change to not secure if already secure
         if (!secure && isSecure_)                //@C2A
@@ -3939,8 +3939,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     public void setSecureCurrentUser(boolean secureCurrentUser)
     {
         String property = "secureCurrentUser";
-        Boolean oldVal = new Boolean(isSecureCurrentUser());
-        Boolean newVal = new Boolean(secureCurrentUser);
+        Boolean oldVal = Boolean.valueOf(isSecureCurrentUser());
+        Boolean newVal = Boolean.valueOf(secureCurrentUser);
 
         if (secureCurrentUser)
             properties_.setString(JDProperties.SECURE_CURRENT_USER, TRUE_);
@@ -4241,8 +4241,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setThreadUsed(boolean threadUsed)
     {
-        Boolean oldValue = new Boolean(isThreadUsed());
-        Boolean newValue = new Boolean(threadUsed);
+        Boolean oldValue = Boolean.valueOf(isThreadUsed());
+        Boolean newValue = Boolean.valueOf(threadUsed);
 
         if (threadUsed)
             properties_.setString(JDProperties.THREAD_USED, TRUE_);
@@ -4362,8 +4362,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     **/
     public void setTrace(boolean trace)
     {
-        Boolean oldValue = new Boolean(isTrace());
-        Boolean newValue = new Boolean(trace);
+        Boolean oldValue = Boolean.valueOf(isTrace());
+        Boolean newValue = Boolean.valueOf(trace);
 
         if (trace)
             properties_.setString(JDProperties.TRACE, TRUE_);
@@ -4426,8 +4426,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     {
         String property = "translateBinary";
 
-        Boolean oldValue = new Boolean(isTranslateBinary());
-        Boolean newValue = new Boolean(translate);
+        Boolean oldValue = Boolean.valueOf(isTranslateBinary());
+        Boolean newValue = Boolean.valueOf(translate);
 
         if (translate)
             properties_.setString(JDProperties.TRANSLATE_BINARY, TRUE_);
@@ -4455,8 +4455,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     {
         String property = "translateBoolean";
 
-        Boolean oldValue = new Boolean(isTranslateBoolean());
-        Boolean newValue = new Boolean(translate);
+        Boolean oldValue = Boolean.valueOf(isTranslateBoolean());
+        Boolean newValue = Boolean.valueOf(translate);
 
         if (translate)
             properties_.setString(JDProperties.TRANSLATE_BOOLEAN, TRUE_);
@@ -4478,8 +4478,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
      public void setUseBlockUpdate(boolean value)
      {
          String property = JDProperties.USE_BLOCK_UPDATE_  ;
-         Boolean oldValue = new Boolean(isUseBlockUpdate());
-         Boolean newValue = new Boolean(value);
+         Boolean oldValue = Boolean.valueOf(isUseBlockUpdate());
+         Boolean newValue = Boolean.valueOf(value);
 
          if (value)
              properties_.setString(JDProperties.USE_BLOCK_UPDATE, TRUE_);
@@ -4501,8 +4501,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
       public void setUseDrdaMetadataVersion(boolean value)
       {
           String property = JDProperties.USE_DRDA_METADATA_VERSION_  ;
-          Boolean oldValue = new Boolean(isUseDrdaMetadataVersion());
-          Boolean newValue = new Boolean(value);
+          Boolean oldValue = Boolean.valueOf(isUseDrdaMetadataVersion());
+          Boolean newValue = Boolean.valueOf(value);
 
           if (value)
               properties_.setString(JDProperties.USE_DRDA_METADATA_VERSION, TRUE_);
@@ -4552,8 +4552,8 @@ implements DataSource, Referenceable, Serializable, Cloneable //@PDC 550
     {
         String property = "variableFieldCompression";
 
-        Boolean oldValue = new Boolean(isVariableFieldCompression());
-        Boolean newValue = new Boolean(compress);
+        Boolean oldValue = Boolean.valueOf(isVariableFieldCompression());
+        Boolean newValue = Boolean.valueOf(compress);
 
         if (compress)
             properties_.setString(JDProperties.VARIABLE_FIELD_COMPRESSION, TRUE_);

--- a/src/main/java/com/ibm/as400/access/AS400JDBCDatabaseMetaData.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCDatabaseMetaData.java
@@ -5429,11 +5429,11 @@ implements DatabaseMetaData
                 data[i][5] = createParameters;
 
             data[i][6]  = new Short ((short) typeNullable);
-            data[i][7]  = new Boolean (typeSample.isText ());                   // @D0C
+            data[i][7]  = Boolean.valueOf(typeSample.isText ());                   // @D0C
             data[i][8]  = new Short ((short) typeSearchable);
-            data[i][9]  = new Boolean (! typeSample.isSigned ());               // @D0C
-            data[i][10] = new Boolean (false);
-            data[i][11] = new Boolean (false);
+            data[i][9]  = Boolean.valueOf(! typeSample.isSigned ());               // @D0C
+            data[i][10] = Boolean.FALSE;
+            data[i][11] = Boolean.FALSE;
 
             String localName = typeSample.getLocalName ();                      // @D0C
             if (localName == null)

--- a/src/main/java/com/ibm/as400/access/AS400JDBCResultSet.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCResultSet.java
@@ -7420,7 +7420,7 @@ implements ResultSet
         if (b == false && wasNull()) { 
           return null;  
         } else { 
-          return new Boolean (b);
+          return Boolean.valueOf(b);
         }
         
       } else if (type == java.sql.Date.class){

--- a/src/main/java/com/ibm/as400/access/AS400JDBCRowSet.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCRowSet.java
@@ -2752,14 +2752,14 @@ implements RowSet, Serializable             // @A3C
     **/
     public void setEscapeProcessing(boolean enable) throws SQLException
     {
-        Boolean old = new Boolean(getEscapeProcessing());
+        Boolean old = Boolean.valueOf(getEscapeProcessing());
 
         validateStatement();
         statement_.setEscapeProcessing(enable);
 
         escapeProcessing_ = enable;      // save it, since it can't be retrieved anywhere else.
 
-        changes_.firePropertyChange("escapeProcessing", old, new Boolean(enable));
+        changes_.firePropertyChange("escapeProcessing", old, Boolean.valueOf(enable));
     }
 
     /**
@@ -3030,8 +3030,8 @@ implements RowSet, Serializable             // @A3C
     {
         String property = "readOnly";
 
-        Boolean oldValue = new Boolean(isReadOnly());
-        Boolean newValue = new Boolean(readOnly);
+        Boolean oldValue = Boolean.valueOf(isReadOnly());
+        Boolean newValue = Boolean.valueOf(readOnly);
 
         if (connection_ != null)
             connection_.setReadOnly(readOnly);
@@ -3243,9 +3243,9 @@ implements RowSet, Serializable             // @A3C
         String property = "useDataSource";
         validateConnection();
 
-        Boolean oldValue = new Boolean(isUseDataSource());
+        Boolean oldValue = Boolean.valueOf(isUseDataSource());
         useDataSource_ = useDataSource;
-        changes_.firePropertyChange(property, oldValue, new Boolean(useDataSource) );
+        changes_.firePropertyChange(property, oldValue, Boolean.valueOf(useDataSource) );
     }
 
     /**

--- a/src/main/java/com/ibm/as400/access/BaseDataQueueImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/BaseDataQueueImplProxy.java
@@ -63,7 +63,7 @@ class BaseDataQueueImplProxy extends AbstractProxyImpl implements BaseDataQueueI
     {
         try
         {
-            connection_.callMethod(pxId_, "create", new Class[] { Integer.TYPE, String.class, Boolean.TYPE, Boolean.TYPE, Integer.TYPE, Boolean.TYPE, String.class }, new Object[] { new Integer(maxEntryLength), authority, new Boolean(saveSenderInformation), new Boolean(FIFO), new Integer(keyLength), new Boolean(forceToAuxiliaryStorage), description });
+            connection_.callMethod(pxId_, "create", new Class[] { Integer.TYPE, String.class, Boolean.TYPE, Boolean.TYPE, Integer.TYPE, Boolean.TYPE, String.class }, new Object[] { new Integer(maxEntryLength), authority, Boolean.valueOf(saveSenderInformation), Boolean.valueOf(FIFO), new Integer(keyLength), Boolean.valueOf(forceToAuxiliaryStorage), description });
         }
         catch (InvocationTargetException e)
         {
@@ -90,7 +90,7 @@ class BaseDataQueueImplProxy extends AbstractProxyImpl implements BaseDataQueueI
     {
         try
         {
-            return (DQReceiveRecord)connection_.callMethod(pxId_, "read", new Class[] { String.class, Integer.TYPE, Boolean.TYPE, byte[].class }, new Object[] { search, new Integer(wait), new Boolean(peek), key }, true).getReturnValue();
+            return (DQReceiveRecord)connection_.callMethod(pxId_, "read", new Class[] { String.class, Integer.TYPE, Boolean.TYPE, byte[].class }, new Object[] { search, new Integer(wait), Boolean.valueOf(peek), key }, true).getReturnValue();
         }
         catch (InvocationTargetException e)
         {
@@ -109,7 +109,7 @@ class BaseDataQueueImplProxy extends AbstractProxyImpl implements BaseDataQueueI
     {
         try
         {
-            return (DQQueryRecord)connection_.callMethod(pxId_, "retrieveAttributes", new Class[] { Boolean.TYPE }, new Object[] { new Boolean(keyed) }).getReturnValue();
+            return (DQQueryRecord)connection_.callMethod(pxId_, "retrieveAttributes", new Class[] { Boolean.TYPE }, new Object[] { Boolean.valueOf(keyed) }).getReturnValue();
         }
         catch (InvocationTargetException e)
         {

--- a/src/main/java/com/ibm/as400/access/ConnectionPool.java
+++ b/src/main/java/com/ibm/as400/access/ConnectionPool.java
@@ -446,12 +446,12 @@ public abstract class ConnectionPool implements Serializable
   {
     String property = "runMaintenance";
 
-//    Boolean oldValue = new Boolean(isRunMaintenance_);
-//    Boolean newValue = new Boolean(cleanup);
+//    Boolean oldValue = Boolean.valueOf(isRunMaintenance_);
+//    Boolean newValue = Boolean.valueOf(cleanup);
     boolean oldValue = isRunMaintenance_;
 
     isRunMaintenance_ = cleanup;
-    if (changes_ != null) changes_.firePropertyChange(property, new Boolean(oldValue), new Boolean(cleanup));
+    if (changes_ != null) changes_.firePropertyChange(property, Boolean.valueOf(oldValue), Boolean.valueOf(cleanup));
   
     if (maintenance_ != null)
     {
@@ -485,8 +485,8 @@ public abstract class ConnectionPool implements Serializable
     //@A4D if (isInUse())
     //@A4D    throw new ExtendedIllegalStateException(property, ExtendedIllegalStateException.PROPERTY_NOT_CHANGED);
 
-    //@A4D Boolean oldValue = new Boolean(isThreadUsed());
-    //@A4D Boolean newValue = new Boolean(useThreads);
+    //@A4D Boolean oldValue = Boolean.valueOf(isThreadUsed());
+    //@A4D Boolean newValue = Boolean.valueOf(useThreads);
 
     //@A4D useThreads_ = useThreads;
     //@A4D changes_.firePropertyChange(property, oldValue, newValue);

--- a/src/main/java/com/ibm/as400/access/ConnectionPoolProperties.java
+++ b/src/main/java/com/ibm/as400/access/ConnectionPoolProperties.java
@@ -338,7 +338,7 @@ class ConnectionPoolProperties implements Serializable
     boolean oldValue = pretestConnections_;
 
     pretestConnections_ = pretest;
-    if (changes_ != null) changes_.firePropertyChange(property, new Boolean(oldValue), new Boolean(pretest));
+    if (changes_ != null) changes_.firePropertyChange(property, Boolean.valueOf(oldValue), Boolean.valueOf(pretest));
 
   }
 
@@ -365,12 +365,12 @@ class ConnectionPoolProperties implements Serializable
     if (isInUse)
       throw new ExtendedIllegalStateException(property, ExtendedIllegalStateException.PROPERTY_NOT_CHANGED);
 
-//    Boolean oldValue = new Boolean(isThreadUsed());
-//    Boolean newValue = new Boolean(useThreads);
+//    Boolean oldValue = Boolean.valueOf(isThreadUsed());
+//    Boolean newValue = Boolean.valueOf(useThreads);
     boolean oldValue = useThreads_;
 
     useThreads_ = useThreads;
-    if (changes_ != null) changes_.firePropertyChange(property, new Boolean(oldValue), new Boolean(useThreads));
+    if (changes_ != null) changes_.firePropertyChange(property, Boolean.valueOf(oldValue), Boolean.valueOf(useThreads));
 
   }
 

--- a/src/main/java/com/ibm/as400/access/DataAreaImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/DataAreaImplProxy.java
@@ -183,7 +183,7 @@ implements DataAreaImpl
        connection_.callMethod (pxId_, "create",
                          new Class[] { Boolean.TYPE,
                                        String.class, String.class},
-                         new Object[] { new Boolean(initialValue),
+                         new Object[] { Boolean.valueOf(initialValue),
                                         textDescription, authority});
      }
      catch (InvocationTargetException e) {
@@ -627,7 +627,7 @@ implements DataAreaImpl
      try {
        connection_.callMethod (pxId_, "write",
                          new Class[] { Boolean.TYPE },
-                         new Object[] { new Boolean(data) });
+                         new Object[] { Boolean.valueOf(data) });
      }
      catch (InvocationTargetException e) {
        throw ProxyClientConnection.rethrow5 (e);

--- a/src/main/java/com/ibm/as400/access/DataQueueAttributes.java
+++ b/src/main/java/com/ibm/as400/access/DataQueueAttributes.java
@@ -334,8 +334,8 @@ public class DataQueueAttributes implements Serializable
         }
         else
         {
-            Boolean oldValue = new Boolean(FIFO_);
-            Boolean newValue = new Boolean(FIFO);
+            Boolean oldValue = Boolean.valueOf(FIFO_);
+            Boolean newValue = Boolean.valueOf(FIFO);
 
             if (vetoableChangeListeners_ != null)
             {
@@ -364,8 +364,8 @@ public class DataQueueAttributes implements Serializable
         }
         else
         {
-            Boolean oldValue = new Boolean(forceToAuxiliaryStorage_);
-            Boolean newValue = new Boolean(forceToAuxiliaryStorage);
+            Boolean oldValue = Boolean.valueOf(forceToAuxiliaryStorage_);
+            Boolean newValue = Boolean.valueOf(forceToAuxiliaryStorage);
 
             if (vetoableChangeListeners_ != null)
             {
@@ -430,8 +430,8 @@ public class DataQueueAttributes implements Serializable
         }
         else
         {
-            Boolean oldValue = new Boolean(saveSenderInfo_);
-            Boolean newValue = new Boolean(saveSenderInfo);
+            Boolean oldValue = Boolean.valueOf(saveSenderInfo_);
+            Boolean newValue = Boolean.valueOf(saveSenderInfo);
 
             if (vetoableChangeListeners_ != null)
             {

--- a/src/main/java/com/ibm/as400/access/IFSFileImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileImplProxy.java
@@ -86,7 +86,7 @@ implements IFSFileImpl
     {
       return ((Boolean)connection_.callMethod(pxId_, "copyTo",
                                               new Class[] { String.class, Boolean.TYPE },
-                                              new Object[] { path, new Boolean(replace) }).getReturnValue()).booleanValue();
+                                              new Object[] { path, Boolean.valueOf(replace) }).getReturnValue()).booleanValue();
     }
     catch (InvocationTargetException e)
     {
@@ -177,7 +177,7 @@ implements IFSFileImpl
     try {
       return connection_.callMethod (pxId_, "getAvailableSpace",
                               new Class[] { Boolean.TYPE },
-                              new Object[] { new Boolean(forUserOnly) })
+                              new Object[] { Boolean.valueOf(forUserOnly) })
         .getReturnValueLong();
     }
     catch (InvocationTargetException e) {
@@ -191,7 +191,7 @@ implements IFSFileImpl
     try {
       return connection_.callMethod (pxId_, "getTotalSpace",
                               new Class[] { Boolean.TYPE },
-                              new Object[] { new Boolean(forUserOnly) })
+                              new Object[] { Boolean.valueOf(forUserOnly) })
         .getReturnValueLong();
     }
     catch (InvocationTargetException e) {
@@ -470,7 +470,7 @@ implements IFSFileImpl
     try {
       return (IFSCachedAttributes[]) connection_.callMethod (pxId_, "listDirectoryDetails",
                               new Class[] { String.class, String.class, Integer.TYPE, byte[].class, Boolean.TYPE },
-                              new Object[] { directoryPattern, directoryPath, new Integer(maxGetCount), restartID, new Boolean(allowSortedRequests) })//@D7C
+                              new Object[] { directoryPattern, directoryPath, new Integer(maxGetCount), restartID, Boolean.valueOf(allowSortedRequests) })//@D7C
         .getReturnValue();
     }
     catch (InvocationTargetException e) {
@@ -564,7 +564,7 @@ implements IFSFileImpl
     try {
       return connection_.callMethod (pxId_, "setAccess",
                                      new Class[] { Integer.TYPE, Boolean.TYPE, Boolean.TYPE },
-                                     new Object[] { new Integer(accessType), new Boolean(enableAccess), new Boolean(ownerOnly) })
+                                     new Object[] { new Integer(accessType), Boolean.valueOf(enableAccess), Boolean.valueOf(ownerOnly) })
         .getReturnValueBoolean();
     }
     catch (InvocationTargetException e) {
@@ -609,7 +609,7 @@ implements IFSFileImpl
     try {
       return connection_.callMethod (pxId_, "setHidden",
                                      new Class[] { Boolean.TYPE },
-                                     new Object[] { new Boolean(attribute) })
+                                     new Object[] { Boolean.valueOf(attribute) })
         .getReturnValueBoolean();
     }
     catch (InvocationTargetException e) {
@@ -665,7 +665,7 @@ implements IFSFileImpl
     try {
       return connection_.callMethod (pxId_, "setReadOnly",
                                      new Class[] { Boolean.TYPE },
-                                     new Object[] { new Boolean(attribute) })
+                                     new Object[] { Boolean.valueOf(attribute) })
         .getReturnValueBoolean();
     }
     catch (InvocationTargetException e) {
@@ -696,7 +696,7 @@ implements IFSFileImpl
     try {
       connection_.callMethod (pxId_, "setSorted",
                               new Class[] { Boolean.TYPE },
-                              new Object[] { new Boolean(sort) });
+                              new Object[] { Boolean.valueOf(sort) });
     }
     catch (InvocationTargetException e) {
       throw ProxyClientConnection.rethrow (e);

--- a/src/main/java/com/ibm/as400/access/IFSFileOutputStream.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileOutputStream.java
@@ -884,8 +884,8 @@ public class IFSFileOutputStream extends OutputStream
                          ExtendedIllegalStateException.PROPERTY_NOT_CHANGED);
     }
 
-    Boolean oldAppend = new Boolean(append_);
-    Boolean newAppend = new Boolean(append);
+    Boolean oldAppend = Boolean.valueOf(append_);
+    Boolean newAppend = Boolean.valueOf(append);
 
     // Fire a vetoable change event for append.
     vetos_.fireVetoableChange("append", oldAppend, newAppend);

--- a/src/main/java/com/ibm/as400/access/IFSFileOutputStreamImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileOutputStreamImplProxy.java
@@ -105,7 +105,7 @@ implements IFSFileOutputStreamImpl
     try {
       connection_.callMethod (pxId_, "setAppend",
                               new Class[] { Boolean.TYPE },
-                              new Object[] { new Boolean(append) });
+                              new Object[] { Boolean.valueOf(append) });
     }
     catch (InvocationTargetException e) {
       throw ProxyClientConnection.rethrow (e);

--- a/src/main/java/com/ibm/as400/access/IFSRandomAccessFileImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/IFSRandomAccessFileImplProxy.java
@@ -121,7 +121,7 @@ implements IFSRandomAccessFileImpl
                                    new Object[] { data,
                                                   new Integer (dataOffset),
                                                   new Integer (length),
-                                                  new Boolean (readFully) },
+                                                  Boolean.valueOf(readFully) },
                                    ARGS_TO_RETURN, readFully );
       // Note: The 6th arg says whether to call the method asynchronously.
       // In the case of readFully, we want asynchronous, since the read
@@ -190,7 +190,7 @@ implements IFSRandomAccessFileImpl
     try {
       connection_.callMethod (pxId_, "setForceToStorage",
                               new Class[] { Boolean.TYPE },
-                              new Object[] { new Boolean(forceToStorage) });
+                              new Object[] { Boolean.valueOf(forceToStorage) });
     }
     catch (InvocationTargetException e) {
       throw ProxyClientConnection.rethrow (e);

--- a/src/main/java/com/ibm/as400/access/JDCallableStatementProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDCallableStatementProxy.java
@@ -963,7 +963,7 @@ implements CallableStatement
         callMethod ("setBoolean",
                     new Class[] { String.class, Boolean.TYPE},
                     new Object[] { parameterName,
-                        new Boolean(parameterValue)});
+                        Boolean.valueOf(parameterValue)});
     }
 
 

--- a/src/main/java/com/ibm/as400/access/JDConnectionProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDConnectionProxy.java
@@ -557,7 +557,7 @@ implements Connection
   {
     callMethod ("setAutoCommit",
                 new Class[] { Boolean.TYPE },
-                new Object[] { new Boolean(autoCommit) });
+                new Object[] { Boolean.valueOf(autoCommit) });
   }
 
 
@@ -690,7 +690,7 @@ implements Connection
   {
     callMethod ("setReadOnly",
                 new Class[] { Boolean.TYPE },
-                new Object[] { new Boolean(readOnly) });
+                new Object[] { Boolean.valueOf(readOnly) });
   }
 
 

--- a/src/main/java/com/ibm/as400/access/JDDatabaseMetaDataProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDDatabaseMetaDataProxy.java
@@ -236,7 +236,7 @@ implements java.sql.DatabaseMetaData
                                               Integer.TYPE, Boolean.TYPE },
                                 new Object[] { catalog, schema, table,
                                                new Integer (scope),
-                                               new Boolean (nullable) });
+                                               Boolean.valueOf(nullable) });
     }
 
 
@@ -437,8 +437,8 @@ implements java.sql.DatabaseMetaData
                                               String.class, Boolean.TYPE,
                                               Boolean.TYPE },
                                 new Object[] { catalog, schema,
-                                               table, new Boolean (unique),
-                                               new Boolean (approximate) });
+                                               table, Boolean.valueOf(unique),
+                                               Boolean.valueOf(approximate) });
     }
 
 

--- a/src/main/java/com/ibm/as400/access/JDNonUniqueFieldMap.java
+++ b/src/main/java/com/ibm/as400/access/JDNonUniqueFieldMap.java
@@ -48,9 +48,9 @@ implements JDFieldMap
         // if serverData == "D", allows duplicate values (set to true)
         //               == "U", must be unique  (set to false)
         if(serverData.toString ().charAt (0) == 'D')
-            return new Boolean (true);
+            return Boolean.TRUE;
         else
-            return new Boolean (false);
+            return Boolean.FALSE;
     }
 
     /**

--- a/src/main/java/com/ibm/as400/access/JDPreparedStatementProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDPreparedStatementProxy.java
@@ -274,7 +274,7 @@ implements PreparedStatement
       callMethod ("setBoolean",
                   new Class[] { Integer.TYPE, Boolean.TYPE },
                   new Object[] { new Integer (parameterIndex),
-                                 new Boolean (parameterValue) });
+                                 Boolean.valueOf(parameterValue) });
     }
 
 

--- a/src/main/java/com/ibm/as400/access/JDResultSetProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDResultSetProxy.java
@@ -1374,7 +1374,7 @@ implements ResultSet
       callMethod ("updateBoolean",
                   new Class[] { Integer.TYPE, Boolean.TYPE },
                   new Object[] { new Integer (columnIndex),
-                                 new Boolean (columnValue) });
+                                 Boolean.valueOf(columnValue) });
     }
 
 

--- a/src/main/java/com/ibm/as400/access/JDStatementProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDStatementProxy.java
@@ -494,7 +494,7 @@ implements java.sql.Statement
     {
       callMethod ("setEscapeProcessing",
                   new Class[] { Boolean.TYPE },
-                  new Object[] { new Boolean (escapeProcessing) });
+                  new Object[] { Boolean.valueOf(escapeProcessing) });
     }
 
 
@@ -579,7 +579,7 @@ implements java.sql.Statement
     {
         callMethod ("setPoolable",
                 new Class[] { Boolean.TYPE },
-                new Object[] { new Boolean (poolable) });  
+                new Object[] { Boolean.valueOf(poolable) });  
     }
     
     //@PDA jdbc40

--- a/src/main/java/com/ibm/as400/access/JDTrace.java
+++ b/src/main/java/com/ibm/as400/access/JDTrace.java
@@ -296,7 +296,7 @@ Logs a property trace message.
   {
     if (isTraceOn())
     {
-      Boolean b = new Boolean(propertyValue);
+      Boolean b = Boolean.valueOf(propertyValue);
       logProperty(object, callingMethod, propertyName, b.toString());
     }
   }

--- a/src/main/java/com/ibm/as400/access/JDUtilities.java
+++ b/src/main/java/com/ibm/as400/access/JDUtilities.java
@@ -946,7 +946,7 @@ class JDUtilities {
           }
         }
       }
-      answer = new Boolean(booleanAnswer);
+      answer = Boolean.valueOf(booleanAnswer);
       interfaceHash.put(interfaceName, answer);
     }
 

--- a/src/main/java/com/ibm/as400/access/JavaApplicationCall.java
+++ b/src/main/java/com/ibm/as400/access/JavaApplicationCall.java
@@ -1170,10 +1170,10 @@ public class JavaApplicationCall implements Serializable
     **/
     public void setFindPort(boolean search)  throws PropertyVetoException
     {
-        Boolean old = new Boolean(findPort_);
-        vetoableChange_.fireVetoableChange("findPort",old,new Boolean(search));
+        Boolean old = Boolean.valueOf(findPort_);
+        vetoableChange_.fireVetoableChange("findPort",old,Boolean.valueOf(search));
         findPort_ = search;
-        propertyChange_.firePropertyChange("findPort",old,new Boolean(search));
+        propertyChange_.firePropertyChange("findPort",old,Boolean.valueOf(search));
     }
 
     /**

--- a/src/main/java/com/ibm/as400/access/NetServer.java
+++ b/src/main/java/com/ibm/as400/access/NetServer.java
@@ -118,7 +118,7 @@ For String-valued attributes, if the current actual value of the corresponding p
 *   ns.setAttributeValue(NetServer.CCSID_PENDING, new Integer(13488));
 *
 *   // Set the (pending) "allow system name" value of the NetServer to true.
-*   ns.setAttributeValue(NetServer.ALLOW_SYSTEM_NAME_PENDING, new Boolean(true));
+*   ns.setAttributeValue(NetServer.ALLOW_SYSTEM_NAME_PENDING, Boolean.TRUE);
 *
 *   // Commit the attribute changes (send them to the system).
 *   ns.commitAttributeChanges();

--- a/src/main/java/com/ibm/as400/access/ObjectDescription.java
+++ b/src/main/java/com/ibm/as400/access/ObjectDescription.java
@@ -1409,11 +1409,11 @@ public class ObjectDescription
       case DIGITALLY_SIGNED:
       case DIGITALLY_SIGNED_TRUSTED:
       case DIGITALLY_SIGNED_MULTIPLE:
-        return new Boolean (((String)o).charAt(0) == '1');
+        return Boolean.valueOf(((String)o).charAt(0) == '1');
       case USAGE_INFO_UPDATED:
-        return new Boolean (((String)o).charAt(0) == 'Y');
+        return Boolean.valueOf(((String)o).charAt(0) == 'Y');
       case JOURNAL_OMITTED_ENTRIES:
-        return new Boolean(((String)o).charAt(0) == '0');
+        return Boolean.valueOf(((String)o).charAt(0) == '0');
 
       default:
         return o;
@@ -1958,7 +1958,7 @@ public class ObjectDescription
 
   void set(int attribute, boolean value)
   {
-    values_.put(attribute, new Boolean(value));
+    values_.put(attribute, Boolean.valueOf(value));
   }
 
   void set(int attribute, Object value)

--- a/src/main/java/com/ibm/as400/access/PrintObjectListImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/PrintObjectListImplProxy.java
@@ -75,7 +75,7 @@ implements PrintObjectListImpl, ProxyImpl
     {
       try
       {
-        connection_.callMethod(pxId_, "setCache", new Class[] { Boolean.TYPE }, new Object[] { new Boolean(b) });
+        connection_.callMethod(pxId_, "setCache", new Class[] { Boolean.TYPE }, new Object[] { Boolean.valueOf(b) });
       }
       catch(InvocationTargetException e)
       {

--- a/src/main/java/com/ibm/as400/access/ProgramCall.java
+++ b/src/main/java/com/ibm/as400/access/ProgramCall.java
@@ -578,7 +578,7 @@ public class ProgramCall implements Serializable
 
     static Boolean getDefaultThreadSafety()
     {
-        return new Boolean(getThreadSafetyProperty());
+        return Boolean.valueOf(getThreadSafetyProperty());
     }
 
     // Check thread safety system property.

--- a/src/main/java/com/ibm/as400/access/PxBooleanParm.java
+++ b/src/main/java/com/ibm/as400/access/PxBooleanParm.java
@@ -93,7 +93,7 @@ Returns the Object value.
 **/
     public Object getObjectValue ()
     {
-        return new Boolean (value_);
+        return Boolean.valueOf(value_);
     }
 
 

--- a/src/main/java/com/ibm/as400/access/RemoteCommandImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/RemoteCommandImplProxy.java
@@ -202,7 +202,7 @@ class RemoteCommandImplProxy extends AbstractProxyImpl implements RemoteCommandI
     {
         try
         {
-            ProxyReturnValue rv = connection_.callMethod(pxId_, "runServiceProgram", new Class[] { String.class, String.class, String.class, Integer.TYPE, ProgramParameter[].class, Boolean.class, Integer.TYPE, Integer.TYPE, Boolean.TYPE }, new Object[] { library,  name, procedureName, new Integer(returnValueFormat), parameterList, threadSafety, new Integer(procedureNameCCSID), new Integer(messageCount), new Boolean(alignOn16Bytes) }, new boolean[] { false, false, false, false, true, false, false, false, false }, true);
+            ProxyReturnValue rv = connection_.callMethod(pxId_, "runServiceProgram", new Class[] { String.class, String.class, String.class, Integer.TYPE, ProgramParameter[].class, Boolean.class, Integer.TYPE, Integer.TYPE, Boolean.TYPE }, new Object[] { library,  name, procedureName, new Integer(returnValueFormat), parameterList, threadSafety, new Integer(procedureNameCCSID), new Integer(messageCount), Boolean.valueOf(alignOn16Bytes) }, new boolean[] { false, false, false, false, true, false, false, false, false }, true);
             ProgramParameter[] returnParmL = (ProgramParameter[])rv.getArgument(4);
             for (int i = 0; i < parameterList.length; ++i)
             {

--- a/src/main/java/com/ibm/as400/access/SQLBoolean.java
+++ b/src/main/java/com/ibm/as400/access/SQLBoolean.java
@@ -85,7 +85,7 @@ final class SQLBoolean extends SQLDataBase {
   // ---------------------------------------------------------//
   public static Boolean getBooleanObject(Object caller, String string) throws SQLException { 
     if (string == null) return null; 
-    return new Boolean(getBoolean(caller,string)); 
+    return Boolean.valueOf(getBoolean(caller,string)); 
   }
   
   public static boolean getBoolean(Object caller, String string)
@@ -128,7 +128,7 @@ final class SQLBoolean extends SQLDataBase {
 
   public static Boolean getBooleanObject(Object caller, Number object) throws SQLException { 
     if (object == null) return null; 
-    return new Boolean(getBoolean(caller,object)); 
+    return Boolean.valueOf(getBoolean(caller,object)); 
   }
 
   public static boolean getBoolean(Object caller, Number object) {
@@ -369,7 +369,7 @@ final class SQLBoolean extends SQLDataBase {
   }
 
   public Object getObject() throws SQLException {
-    return new Boolean(value_);
+    return Boolean.valueOf(value_);
   }
 
   public short getShort() throws SQLException {
@@ -434,7 +434,7 @@ final class SQLBoolean extends SQLDataBase {
   // @array
 
   public void saveValue() {
-    savedValue_ = new Boolean(value_);
+    savedValue_ = Boolean.valueOf(value_);
   }
 
 }

--- a/src/main/java/com/ibm/as400/access/UserSpace.java
+++ b/src/main/java/com/ibm/as400/access/UserSpace.java
@@ -797,8 +797,8 @@ public class UserSpace implements Serializable
         }
         else
         {
-            Boolean oldValue = new Boolean(mustUseProgramCall_);
-            Boolean newValue = new Boolean(useProgramCall);
+            Boolean oldValue = Boolean.valueOf(mustUseProgramCall_);
+            Boolean newValue = Boolean.valueOf(useProgramCall);
 
             mustUseProgramCall_ = useProgramCall;
 
@@ -837,8 +837,8 @@ public class UserSpace implements Serializable
        }
        else
        {
-           Boolean oldValue = new Boolean(mustUseNativeMethods_);
-           Boolean newValue = new Boolean(useNativeMethods);
+           Boolean oldValue = Boolean.valueOf(mustUseNativeMethods_);
+           Boolean newValue = Boolean.valueOf(useNativeMethods);
 
            mustUseNativeMethods_ = useNativeMethods;
 
@@ -1120,8 +1120,8 @@ public class UserSpace implements Serializable
         }
         else
         {
-            Boolean oldValue = new Boolean(mustUseSockets_);
-            Boolean newValue = new Boolean(mustUseSockets);
+            Boolean oldValue = Boolean.valueOf(mustUseSockets_);
+            Boolean newValue = Boolean.valueOf(mustUseSockets);
 
             mustUseSockets_ = mustUseSockets;
 

--- a/src/main/java/com/ibm/as400/access/UserSpaceImplProxy.java
+++ b/src/main/java/com/ibm/as400/access/UserSpaceImplProxy.java
@@ -42,7 +42,7 @@ class UserSpaceImplProxy extends AbstractProxyImpl implements UserSpaceImpl
     {
         try
         {
-            connection_.callMethod(pxId_, "create", new Class[] { byte[].class, Integer.TYPE, Boolean.TYPE, String.class, Byte.TYPE, String.class, String.class }, new Object[] { domainBytes, new Integer(length), new Boolean(replace), extendedAttribute, new Byte(initialValue), textDescription, authority } );
+            connection_.callMethod(pxId_, "create", new Class[] { byte[].class, Integer.TYPE, Boolean.TYPE, String.class, Byte.TYPE, String.class, String.class }, new Object[] { domainBytes, new Integer(length), Boolean.valueOf(replace), extendedAttribute, new Byte(initialValue), textDescription, authority } );
         }
         catch (InvocationTargetException e)
         {
@@ -120,7 +120,7 @@ class UserSpaceImplProxy extends AbstractProxyImpl implements UserSpaceImpl
     {
         try
         {
-            connection_.callMethod(pxId_, "setAutoExtendible", new Class[] { Boolean.TYPE }, new Object[] { new Boolean(autoExtendibility) } );
+            connection_.callMethod(pxId_, "setAutoExtendible", new Class[] { Boolean.TYPE }, new Object[] { Boolean.valueOf(autoExtendibility) } );
         }
         catch (InvocationTargetException e)
         {
@@ -156,7 +156,7 @@ class UserSpaceImplProxy extends AbstractProxyImpl implements UserSpaceImpl
     {
         try
         {
-            connection_.callMethod(pxId_, "setProperties", new Class[] { AS400Impl.class, String.class, String.class, String.class, Boolean.TYPE, Boolean.TYPE }, new Object[] { system, path, name, library, new Boolean(mustUseProgramCall), new Boolean(mustUseSockets) } );
+            connection_.callMethod(pxId_, "setProperties", new Class[] { AS400Impl.class, String.class, String.class, String.class, Boolean.TYPE, Boolean.TYPE }, new Object[] { system, path, name, library, Boolean.valueOf(mustUseProgramCall), Boolean.valueOf(mustUseSockets) } );
         }
         catch (InvocationTargetException e)
         {

--- a/src/main/java/com/ibm/as400/access/jdbcClient/Main.java
+++ b/src/main/java/com/ibm/as400/access/jdbcClient/Main.java
@@ -2015,7 +2015,7 @@ public class Main implements Runnable {
             java.lang.reflect.Method method = traceClass.getMethod(
                 "setCliTrace", argClasses);
             Object[] args = new Object[1];
-            args[0] = new Boolean(b);
+            args[0] = Boolean.valueOf(b);
             method.invoke(null, args);
 
           } catch (Exception e) {
@@ -2890,7 +2890,7 @@ public class Main implements Runnable {
                             }
                           } else if (parameterTypeName.equals("boolean")) {
                             try {
-                              parameters[p] = new Boolean(arg);
+                              parameters[p] = Boolean.valueOf(arg);
                             } catch (Exception e) {
                               possibleErrors.append("Could not parse " + arg
                                   + " as integer\n");
@@ -3250,7 +3250,7 @@ public class Main implements Runnable {
                       }
                     } else if (parameterTypeName.equals("boolean")) {
                       try {
-                        parameters[p] = new Boolean(arg);
+                        parameters[p] = Boolean.valueOf(arg);
                       } catch (Exception e) {
                         possibleErrors.append("Could not parse " + arg
                             + " as integer\n");
@@ -4730,7 +4730,7 @@ public class Main implements Runnable {
               // Toolbox does not handle native types on convert
               Boolean[] newParameter = new Boolean[arrayCardinality];
               for (int i = 0; i < arrayCardinality; i++) {
-                newParameter[i] = new Boolean(parameter[i]);
+                newParameter[i] = Boolean.valueOf(parameter[i]);
               }
 
               cstmt.setArray(parm, makeArray(newParameter, "BOOLEAN"));

--- a/src/main/java/com/ibm/as400/access/jdbcClient/ReflectionUtil.java
+++ b/src/main/java/com/ibm/as400/access/jdbcClient/ReflectionUtil.java
@@ -1301,7 +1301,7 @@ public class ReflectionUtil {
     method = thisClass.getMethod(methodName, argTypes);
     method.setAccessible(true); // allow toolbox proxy methods to be invoked
     Object[] args = new Object[1];
-    args[0] = new Boolean(parm1);
+    args[0] = Boolean.valueOf(parm1);
     try {
       method.invoke(o, args);
     } catch (java.lang.reflect.InvocationTargetException ite) {
@@ -1623,7 +1623,7 @@ public class ReflectionUtil {
     }
     Object[] args = new Object[2];
     args[0] = parm1;
-    args[1] = new Boolean(b);
+    args[1] = Boolean.valueOf(b);
     try {
       method.invoke(o, args);
     } catch (java.lang.reflect.InvocationTargetException ite) {

--- a/src/main/java/com/ibm/as400/security/auth/AS400Credential.java
+++ b/src/main/java/com/ibm/as400/security/auth/AS400Credential.java
@@ -934,7 +934,7 @@ public abstract class AS400Credential implements java.io.Serializable, AS400Swap
    void setIsRenewable(boolean b)
    {
       validatePropertyChange("isRenewable");
-      renewable_ = new Boolean(b);
+      renewable_ = Boolean.valueOf(b);
    }
    /**
     * Indicates if the credential is sufficient by itself
@@ -957,7 +957,7 @@ public abstract class AS400Credential implements java.io.Serializable, AS400Swap
    void setIsStandalone(boolean b)
    {
       validatePropertyChange("isStandalone");
-      standalone_ = new Boolean(b);
+      standalone_ = Boolean.valueOf(b);
    }
    /**
     * Indicates if the credential will expire based on time.
@@ -979,7 +979,7 @@ public abstract class AS400Credential implements java.io.Serializable, AS400Swap
    void setIsTimed(boolean b)
    {
       validatePropertyChange("isTimed");
-      timed_ = new Boolean(b);
+      timed_ = Boolean.valueOf(b);
    }
    /**
     * Sets the principal associated with the credential.

--- a/src/main/java/com/ibm/as400/util/html/HTMLList.java
+++ b/src/main/java/com/ibm/as400/util/html/HTMLList.java
@@ -405,7 +405,7 @@ public abstract class HTMLList extends HTMLTagAttributes implements java.io.Seri
 
         compact_ = compact;
 
-        if (changes_ != null) changes_.firePropertyChange("compact", new Boolean(old), new Boolean(compact) ); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("compact", Boolean.valueOf(old), Boolean.valueOf(compact) ); //@CRS
     }
 
 

--- a/src/main/java/com/ibm/as400/util/html/HTMLTable.java
+++ b/src/main/java/com/ibm/as400/util/html/HTMLTable.java
@@ -1344,15 +1344,15 @@ public class HTMLTable extends HTMLTagAttributes implements HTMLConstants, Seria
     **/
     public void setHeaderInUse(boolean headerInUse) throws PropertyVetoException
     {
-        //@CRS Boolean oldUse = new Boolean(headerInUse_);
-        //@CRS Boolean newUse = new Boolean(headerInUse);
+        //@CRS Boolean oldUse = Boolean.valueOf(headerInUse_);
+        //@CRS Boolean newUse = Boolean.valueOf(headerInUse);
         boolean oldUse = headerInUse_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("useHeader", new Boolean(oldUse), new Boolean(headerInUse)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("useHeader", Boolean.valueOf(oldUse), Boolean.valueOf(headerInUse)); //@CRS
 
         headerInUse_ = headerInUse;
 
-        if (changes_ != null) changes_.firePropertyChange("useHeader", new Boolean(oldUse), new Boolean(headerInUse)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("useHeader", Boolean.valueOf(oldUse), Boolean.valueOf(headerInUse)); //@CRS
     }
 
     /**
@@ -1462,15 +1462,15 @@ public class HTMLTable extends HTMLTagAttributes implements HTMLConstants, Seria
     **/
     public void setWidthInPercent(boolean widthInPercent) throws PropertyVetoException
     {
-        //@CRS Boolean oldValue = new Boolean(widthPercent_);
-        //@CRS Boolean newValue = new Boolean(widthInPercent);
+        //@CRS Boolean oldValue = Boolean.valueOf(widthPercent_);
+        //@CRS Boolean newValue = Boolean.valueOf(widthInPercent);
         boolean oldValue = widthPercent_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("widthInPercent", new Boolean(oldValue), new Boolean(widthInPercent)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("widthInPercent", Boolean.valueOf(oldValue), Boolean.valueOf(widthInPercent)); //@CRS
 
         widthPercent_ = widthInPercent;
 
-        if (changes_ != null) changes_.firePropertyChange("widthInPercent", new Boolean(oldValue), new Boolean(widthInPercent)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("widthInPercent", Boolean.valueOf(oldValue), Boolean.valueOf(widthInPercent)); //@CRS
     }
 
     /** 

--- a/src/main/java/com/ibm/as400/util/html/HTMLTableCell.java
+++ b/src/main/java/com/ibm/as400/util/html/HTMLTableCell.java
@@ -702,15 +702,15 @@ public class HTMLTableCell extends HTMLTagAttributes implements HTMLConstants, S
     **/
     public void setHeightInPercent(boolean heightInPercent) throws PropertyVetoException
     {
-        //@CRS Boolean oldHeight = new Boolean(heightPercent_);
-        //@CRS Boolean newHeight = new Boolean(heightInPercent);
+        //@CRS Boolean oldHeight = Boolean.valueOf(heightPercent_);
+        //@CRS Boolean newHeight = Boolean.valueOf(heightInPercent);
       boolean oldHeight = heightPercent_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("heightInPercent", new Boolean(oldHeight), new Boolean(heightInPercent)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("heightInPercent", Boolean.valueOf(oldHeight), Boolean.valueOf(heightInPercent)); //@CRS
 
         heightPercent_ = heightInPercent;
 
-        if (changes_ != null) changes_.firePropertyChange("heightInPercent", new Boolean(oldHeight), new Boolean(heightInPercent)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("heightInPercent", Boolean.valueOf(oldHeight), Boolean.valueOf(heightInPercent)); //@CRS
     }
 
     /**
@@ -918,15 +918,15 @@ public class HTMLTableCell extends HTMLTagAttributes implements HTMLConstants, S
     **/
     public void setWidthInPercent(boolean widthInPercent) throws PropertyVetoException
     {
-        //@CRS Boolean oldWidth = new Boolean(widthPercent_);
-        //@CRS Boolean newWidth = new Boolean(widthInPercent);
+        //@CRS Boolean oldWidth = Boolean.valueOf(widthPercent_);
+        //@CRS Boolean newWidth = Boolean.valueOf(widthInPercent);
       boolean oldWidth = widthPercent_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("widthInPercent", new Boolean(oldWidth), new Boolean(widthInPercent)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("widthInPercent", Boolean.valueOf(oldWidth), Boolean.valueOf(widthInPercent)); //@CRS
 
         widthPercent_ = widthInPercent;
 
-        if (changes_ != null) changes_.firePropertyChange("widthInPercent", new Boolean(oldWidth), new Boolean(widthInPercent)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("widthInPercent", Boolean.valueOf(oldWidth), Boolean.valueOf(widthInPercent)); //@CRS
     }
 
     /**
@@ -937,15 +937,15 @@ public class HTMLTableCell extends HTMLTagAttributes implements HTMLConstants, S
     **/
     public void setWrap(boolean wrap) throws PropertyVetoException
     {
-        //@CRS Boolean oldWrap = new Boolean(wrap_);
-        //@CRS Boolean newWrap = new Boolean(wrap);
+        //@CRS Boolean oldWrap = Boolean.valueOf(wrap_);
+        //@CRS Boolean newWrap = Boolean.valueOf(wrap);
         boolean oldWrap = wrap_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("wrap", new Boolean(oldWrap), new Boolean(wrap)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("wrap", Boolean.valueOf(oldWrap), Boolean.valueOf(wrap)); //@CRS
 
         wrap_ = wrap;
 
-        if (changes_ != null) changes_.firePropertyChange("wrap", new Boolean(oldWrap), new Boolean(wrap)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("wrap", Boolean.valueOf(oldWrap), Boolean.valueOf(wrap)); //@CRS
     }
 
     /**

--- a/src/main/java/com/ibm/as400/util/html/HTMLText.java
+++ b/src/main/java/com/ibm/as400/util/html/HTMLText.java
@@ -732,15 +732,15 @@ public class HTMLText extends HTMLTagAttributes implements HTMLConstants, Serial
     **/
     public void setBold(boolean bold) throws PropertyVetoException
     {
-        //@CRS Boolean oldBold = new Boolean(bold_);
-        //@CRS Boolean newBold = new Boolean(bold);
+        //@CRS Boolean oldBold = Boolean.valueOf(bold_);
+        //@CRS Boolean newBold = Boolean.valueOf(bold);
       boolean oldBold = bold_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("bold", new Boolean(oldBold), new Boolean(bold)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("bold", Boolean.valueOf(oldBold), Boolean.valueOf(bold)); //@CRS
 
         bold_ = bold;
 
-        if (changes_ != null) changes_.firePropertyChange("bold", new Boolean(oldBold), new Boolean(bold)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("bold", Boolean.valueOf(oldBold), Boolean.valueOf(bold)); //@CRS
     }
 
     /**
@@ -799,15 +799,15 @@ public class HTMLText extends HTMLTagAttributes implements HTMLConstants, Serial
     **/
     public void setFixed(boolean fixed) throws PropertyVetoException
     {
-        //@CRS Boolean oldFixed = new Boolean(fixed_);
-        //@CRS Boolean newFixed = new Boolean(fixed);
+        //@CRS Boolean oldFixed = Boolean.valueOf(fixed_);
+        //@CRS Boolean newFixed = Boolean.valueOf(fixed);
       boolean oldFixed = fixed_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("fixed", new Boolean(oldFixed), new Boolean(fixed)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("fixed", Boolean.valueOf(oldFixed), Boolean.valueOf(fixed)); //@CRS
 
         fixed_ = fixed;
 
-        if (changes_ != null) changes_.firePropertyChange("fixed", new Boolean(oldFixed), new Boolean(fixed)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("fixed", Boolean.valueOf(oldFixed), Boolean.valueOf(fixed)); //@CRS
     }
 
     /**
@@ -817,15 +817,15 @@ public class HTMLText extends HTMLTagAttributes implements HTMLConstants, Serial
     **/
     public void setItalic(boolean italic) throws PropertyVetoException
     {
-        //@CRS Boolean oldItalic = new Boolean(italic_);
-        //@CRS Boolean newItalic = new Boolean(italic);
+        //@CRS Boolean oldItalic = Boolean.valueOf(italic_);
+        //@CRS Boolean newItalic = Boolean.valueOf(italic);
       boolean oldItalic = italic_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("italic", new Boolean(oldItalic), new Boolean(italic)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("italic", Boolean.valueOf(oldItalic), Boolean.valueOf(italic)); //@CRS
 
         italic_ = italic;
 
-        if (changes_ != null) changes_.firePropertyChange("italic", new Boolean(oldItalic), new Boolean(italic)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("italic", Boolean.valueOf(oldItalic), Boolean.valueOf(italic)); //@CRS
     }
 
     /**
@@ -896,15 +896,15 @@ public class HTMLText extends HTMLTagAttributes implements HTMLConstants, Serial
     **/
     public void setUnderscore(boolean underscore) throws PropertyVetoException
     {
-        //@CRS Boolean oldUnderscore = new Boolean(underscore_);
-        //@CRS Boolean newUnderscore = new Boolean(underscore);
+        //@CRS Boolean oldUnderscore = Boolean.valueOf(underscore_);
+        //@CRS Boolean newUnderscore = Boolean.valueOf(underscore);
         boolean oldUnderscore = underscore_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("underscore", new Boolean(oldUnderscore), new Boolean(underscore)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("underscore", Boolean.valueOf(oldUnderscore), Boolean.valueOf(underscore)); //@CRS
 
         underscore_ = underscore;
 
-        if (changes_ != null) changes_.firePropertyChange("underscore", new Boolean(oldUnderscore), new Boolean(underscore)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("underscore", Boolean.valueOf(oldUnderscore), Boolean.valueOf(underscore)); //@CRS
     }
 
     /** 

--- a/src/main/java/com/ibm/as400/util/html/HTMLTreeElement.java
+++ b/src/main/java/com/ibm/as400/util/html/HTMLTreeElement.java
@@ -607,7 +607,7 @@ public class HTMLTreeElement implements HTMLTagElement, java.io.Serializable
 
                 expanded_ = !expanded_;
 
-                if (changes_ != null) changes_.firePropertyChange("selected", new Boolean(old), new Boolean(expanded_)); //@P2C
+                if (changes_ != null) changes_.firePropertyChange("selected", Boolean.valueOf(old), Boolean.valueOf(expanded_)); //@P2C
             }
             else
             {
@@ -683,7 +683,7 @@ public class HTMLTreeElement implements HTMLTagElement, java.io.Serializable
 
         expanded_ = expanded;
 
-        if (changes_ != null) changes_.firePropertyChange("expanded", new Boolean(old), new Boolean(expanded_)); //@P2C
+        if (changes_ != null) changes_.firePropertyChange("expanded", Boolean.valueOf(old), Boolean.valueOf(expanded_)); //@P2C
     }
 
 

--- a/src/main/java/com/ibm/as400/util/html/RadioFormInputGroup.java
+++ b/src/main/java/com/ibm/as400/util/html/RadioFormInputGroup.java
@@ -432,15 +432,15 @@ public class RadioFormInputGroup extends HTMLTagAttributes implements java.io.Se
     public void setVerticalAlignment(boolean verticalAlignment)                        //$A3A
     throws PropertyVetoException
     {
-        //@CRS Boolean oldAlign = new Boolean(useVertAlign_);
-        //@CRS Boolean newAlign = new Boolean(verticalAlignment);
+        //@CRS Boolean oldAlign = Boolean.valueOf(useVertAlign_);
+        //@CRS Boolean newAlign = Boolean.valueOf(verticalAlignment);
       boolean oldAlign = useVertAlign_; //@CRS
 
-        if (vetos_ != null) vetos_.fireVetoableChange("verticalAlignment", new Boolean(oldAlign), new Boolean(verticalAlignment)); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("verticalAlignment", Boolean.valueOf(oldAlign), Boolean.valueOf(verticalAlignment)); //@CRS
 
         useVertAlign_ = verticalAlignment;
 
-        if (changes_ != null) changes_.firePropertyChange("verticalAlignment", new Boolean(oldAlign), new Boolean(verticalAlignment)); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("verticalAlignment", Boolean.valueOf(oldAlign), Boolean.valueOf(verticalAlignment)); //@CRS
 
     }
 

--- a/src/main/java/com/ibm/as400/util/html/SelectFormElement.java
+++ b/src/main/java/com/ibm/as400/util/html/SelectFormElement.java
@@ -523,11 +523,11 @@ public class SelectFormElement extends HTMLTagAttributes implements java.io.Seri
         //@C1D
 
         boolean old = multiple_;
-        if (vetos_ != null) vetos_.fireVetoableChange("multiple", new Boolean(old), new Boolean(multiple) ); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("multiple", Boolean.valueOf(old), Boolean.valueOf(multiple) ); //@CRS
 
         multiple_ = multiple;
 
-        if (changes_ != null) changes_.firePropertyChange("multiple", new Boolean(old), new Boolean(multiple) ); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("multiple", Boolean.valueOf(old), Boolean.valueOf(multiple) ); //@CRS
     }
 
     /**

--- a/src/main/java/com/ibm/as400/util/html/SelectOption.java
+++ b/src/main/java/com/ibm/as400/util/html/SelectOption.java
@@ -364,11 +364,11 @@ public class SelectOption extends HTMLTagAttributes implements java.io.Serializa
 
         boolean old = selected_;
 
-        if (vetos_ != null) vetos_.fireVetoableChange("selected", new Boolean(old), new Boolean(selected) ); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("selected", Boolean.valueOf(old), Boolean.valueOf(selected) ); //@CRS
 
         selected_ = selected;
 
-        if (changes_ != null) changes_.firePropertyChange("selected", new Boolean(old), new Boolean(selected) ); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("selected", Boolean.valueOf(old), Boolean.valueOf(selected) ); //@CRS
     }
     
     /**

--- a/src/main/java/com/ibm/as400/util/html/ToggleFormInput.java
+++ b/src/main/java/com/ibm/as400/util/html/ToggleFormInput.java
@@ -121,11 +121,11 @@ public abstract class ToggleFormInput extends FormInput
         //@A1D
 
         boolean old = checked_;
-        if (vetos_ != null) vetos_.fireVetoableChange("checked", new Boolean(old), new Boolean(checked) ); //@CRS
+        if (vetos_ != null) vetos_.fireVetoableChange("checked", Boolean.valueOf(old), Boolean.valueOf(checked) ); //@CRS
 
         checked_ = checked;
 
-        if (changes_ != null) changes_.firePropertyChange("checked", new Boolean(old), new Boolean(checked) ); //@CRS
+        if (changes_ != null) changes_.firePropertyChange("checked", Boolean.valueOf(old), Boolean.valueOf(checked) ); //@CRS
     }
 
     /**

--- a/src/main/java/com/ibm/as400/vaccess/IFSList.java
+++ b/src/main/java/com/ibm/as400/vaccess/IFSList.java
@@ -374,11 +374,11 @@ class IFSList extends java.awt.List
       **/
     public void setSort(boolean sort)
     {
-        Boolean old = new Boolean(sort_);
+        Boolean old = Boolean.valueOf(sort_);
 
         sort_ = sort;
 
-        propertyList.firePropertyChange("sort", old, new Boolean(sort_));
+        propertyList.firePropertyChange("sort", old, Boolean.valueOf(sort_));
     }
 
     /**

--- a/src/main/java/com/ibm/as400/vaccess/PermissionTableModelDLO.java
+++ b/src/main/java/com/ibm/as400/vaccess/PermissionTableModelDLO.java
@@ -184,22 +184,22 @@ class PermissionTableModelDLO extends DefaultTableModel
                    value = new PermissionNameCellObject(user.getUserID(),user.getGroupIndicator());
                    break;
             case 1 :
-                   value = new Boolean(authorityValue.equals("*USE"));
+                   value = Boolean.valueOf(authorityValue.equals("*USE"));
                    break;
             case 2 :
-                   value = new Boolean(authorityValue.equals("*CHANGE"));
+                   value = Boolean.valueOf(authorityValue.equals("*CHANGE"));
                    break;
             case 3 :
-                   value = new Boolean(authorityValue.equals("*ALL"));
+                   value = Boolean.valueOf(authorityValue.equals("*ALL"));
                    break;
             case 4 :
-                   value = new Boolean(authorityValue.equals("*EXCLUDE"));
+                   value = Boolean.valueOf(authorityValue.equals("*EXCLUDE"));
                    break;
             case 5 :
-                   value = new Boolean(user.isFromAuthorizationList());
+                   value = Boolean.valueOf(user.isFromAuthorizationList());
                    break;
             case 6:                                                        //@A2A
-                   value = new Boolean(authorityValue.equals("USER_DEF")); //@A2A
+                   value = Boolean.valueOf(authorityValue.equals("USER_DEF")); //@A2A
                    break;                                                  //@A2A
         }
         return value;
@@ -282,7 +282,7 @@ class PermissionTableModelDLO extends DefaultTableModel
         int row = userPermissions_.indexOf(up);
         if (row >= 0)
         {
-          setValueAt(new Boolean(false), row, 5);
+          setValueAt(Boolean.FALSE, row, 5);
         }
     }
 

--- a/src/main/java/com/ibm/as400/vaccess/PermissionTableModelQSYS.java
+++ b/src/main/java/com/ibm/as400/vaccess/PermissionTableModelQSYS.java
@@ -199,52 +199,52 @@ class PermissionTableModelQSYS extends DefaultTableModel
                    value = new PermissionNameCellObject(user.getUserID(),user.getGroupIndicator());
                    break;
             case 1 :
-                   value = new Boolean(authorityValue.equals("*USE"));
+                   value = Boolean.valueOf(authorityValue.equals("*USE"));
                    break;
             case 2 :
-                   value = new Boolean(authorityValue.equals("*CHANGE"));
+                   value = Boolean.valueOf(authorityValue.equals("*CHANGE"));
                    break;
             case 3 :
-                   value = new Boolean(authorityValue.equals("*ALL"));
+                   value = Boolean.valueOf(authorityValue.equals("*ALL"));
                    break;
             case 4 :
-                   value = new Boolean(authorityValue.equals("*EXCLUDE"));
+                   value = Boolean.valueOf(authorityValue.equals("*EXCLUDE"));
                    break;
             case 5 :
                    if (isAuthorizationList_)
-                     value = new Boolean(user.isAuthorizationListManagement());
+                     value = Boolean.valueOf(user.isAuthorizationListManagement());
                    else
-                     value = new Boolean(user.isFromAuthorizationList());
+                     value = Boolean.valueOf(user.isFromAuthorizationList());
                    break;
             case 6 :
-                   value = new Boolean(user.isOperational());
+                   value = Boolean.valueOf(user.isOperational());
                    break;
             case 7 :
-                   value = new Boolean(user.isManagement());
+                   value = Boolean.valueOf(user.isManagement());
                    break;
             case 8 :
-                   value = new Boolean(user.isExistence());
+                   value = Boolean.valueOf(user.isExistence());
                    break;
             case 9 :
-                   value = new Boolean(user.isAlter());
+                   value = Boolean.valueOf(user.isAlter());
                    break;
             case 10 :
-                   value = new Boolean(user.isReference());
+                   value = Boolean.valueOf(user.isReference());
                    break;
             case 11 :
-                   value = new Boolean(user.isRead());
+                   value = Boolean.valueOf(user.isRead());
                    break;
             case 12 :
-                   value = new Boolean(user.isAdd());
+                   value = Boolean.valueOf(user.isAdd());
                    break;
             case 13 :
-                   value = new Boolean(user.isUpdate());
+                   value = Boolean.valueOf(user.isUpdate());
                    break;
             case 14 :
-                   value = new Boolean(user.isDelete());
+                   value = Boolean.valueOf(user.isDelete());
                    break;
             case 15 :
-                   value = new Boolean(user.isExecute());
+                   value = Boolean.valueOf(user.isExecute());
                    break;
         }
         return value;
@@ -348,7 +348,7 @@ class PermissionTableModelQSYS extends DefaultTableModel
         int row = userPermissions_.indexOf(up);
         if (row >= 0)
         {
-          setValueAt(new Boolean(false), row, 5);
+          setValueAt(Boolean.FALSE, row, 5);
         }
     }
 

--- a/src/main/java/com/ibm/as400/vaccess/PermissionTableModelRoot.java
+++ b/src/main/java/com/ibm/as400/vaccess/PermissionTableModelRoot.java
@@ -196,29 +196,29 @@ class PermissionTableModelRoot extends DefaultTableModel
                    value = new PermissionNameCellObject(user.getUserID(),user.getGroupIndicator());
                    break;
             case 1 :
-                   value = new Boolean(authorityValue.indexOf("R") > -1);
+                   value = Boolean.valueOf(authorityValue.indexOf("R") > -1);
                    break;
             case 2 :
-                   value = new Boolean(authorityValue.indexOf("W") > -1);
+                   value = Boolean.valueOf(authorityValue.indexOf("W") > -1);
                    break;
             case 3 :
-                   value = new Boolean((authorityValue.indexOf("X") > -1) &&
+                   value = Boolean.valueOf((authorityValue.indexOf("X") > -1) &&
                                        (authorityValue.indexOf("E") == -1));
                    break;
             case 4 :
-                   value = new Boolean(user.isManagement());
+                   value = Boolean.valueOf(user.isManagement());
                    break;
             case 5 :
-                   value = new Boolean(user.isExistence());
+                   value = Boolean.valueOf(user.isExistence());
                    break;
             case 6 :
-                   value = new Boolean(user.isAlter());
+                   value = Boolean.valueOf(user.isAlter());
                    break;
             case 7 :
-                   value = new Boolean(user.isReference());
+                   value = Boolean.valueOf(user.isReference());
                    break;
             case 8 :
-                   value = new Boolean(user.isFromAuthorizationList());
+                   value = Boolean.valueOf(user.isFromAuthorizationList());
                    break;
         }
         return value;
@@ -300,7 +300,7 @@ class PermissionTableModelRoot extends DefaultTableModel
         int row = userPermissions_.indexOf(up);
         if (row >= 0)
         {
-          setValueAt(new Boolean(false), row, 8);
+          setValueAt(Boolean.FALSE, row, 8);
         }
     }
 

--- a/src/main/java/com/ibm/as400/vaccess/RecordListFormPane.java
+++ b/src/main/java/com/ibm/as400/vaccess/RecordListFormPane.java
@@ -912,16 +912,16 @@ until a <i>load()</i> is done.
 public void setKeyed (boolean keyed)
     throws PropertyVetoException
 {
-    Boolean old = new Boolean(getKeyed());
+    Boolean old = Boolean.valueOf(getKeyed());
 
     // Fire a vetoable change event.
-    fireVetoableChange("keyed", old, new Boolean(keyed));
+    fireVetoableChange("keyed", old, Boolean.valueOf(keyed));
 
     // Make property change.
     tableData_.setKeyed(keyed);
 
     // Fire the property change event.
-    firePropertyChange("keyed", old, new Boolean(keyed));
+    firePropertyChange("keyed", old, Boolean.valueOf(keyed));
 }
 
 

--- a/src/main/java/com/ibm/as400/vaccess/RecordListTableModel.java
+++ b/src/main/java/com/ibm/as400/vaccess/RecordListTableModel.java
@@ -814,16 +814,16 @@ until a <i>load()</i> is done.
 public void setKeyed (boolean keyed)
     throws PropertyVetoException
 {
-    Boolean old = new Boolean(getKeyed());
+    Boolean old = Boolean.valueOf(getKeyed());
 
     // Fire a vetoable change event.
-    vetoListeners_.fireVetoableChange("keyed", old, new Boolean(keyed));
+    vetoListeners_.fireVetoableChange("keyed", old, Boolean.valueOf(keyed));
 
     // Make property change.
     tableData_.setKeyed(keyed);
 
     // Fire the property change event.
-    changeListeners_.firePropertyChange("keyed", old, new Boolean(keyed));
+    changeListeners_.firePropertyChange("keyed", old, Boolean.valueOf(keyed));
 }
 
 

--- a/src/main/java/com/ibm/as400/vaccess/ResourceListDetailsPane.java
+++ b/src/main/java/com/ibm/as400/vaccess/ResourceListDetailsPane.java
@@ -604,7 +604,7 @@ Sets whether pop-up menus are enabled.
 **/
     public void setAllowActions(boolean allowActions)
     {
-        Boolean oldValue = new Boolean(allowActions_);
+        Boolean oldValue = Boolean.valueOf(allowActions_);
 
         allowActions_ = allowActions;
         if (allowActions_) {
@@ -616,7 +616,7 @@ Sets whether pop-up menus are enabled.
             table_.removeMouseListener(popupMenuAdapter_);
         }
 
-        propertyChangeSupport_.firePropertyChange("allowActions", oldValue, new Boolean(allowActions));
+        propertyChangeSupport_.firePropertyChange("allowActions", oldValue, Boolean.valueOf(allowActions));
     }
 
 

--- a/src/main/java/com/ibm/as400/vaccess/ResourceListPane.java
+++ b/src/main/java/com/ibm/as400/vaccess/ResourceListPane.java
@@ -478,7 +478,7 @@ Sets whether pop-up menus are enabled.
 **/
     public void setAllowActions(boolean allowActions)
     {
-        Boolean oldValue = new Boolean(allowActions_);
+        Boolean oldValue = Boolean.valueOf(allowActions_);
 
         allowActions_ = allowActions;
         if (allowActions_)
@@ -486,7 +486,7 @@ Sets whether pop-up menus are enabled.
         else
             list_.removeMouseListener(popupMenuAdapter_);
 
-        propertyChangeSupport_.firePropertyChange("allowActions", oldValue, new Boolean(allowActions));
+        propertyChangeSupport_.firePropertyChange("allowActions", oldValue, Boolean.valueOf(allowActions));
     }
 
 

--- a/src/main/java/com/ibm/as400/vaccess/ResourceListPropertiesTabbedPane.java
+++ b/src/main/java/com/ibm/as400/vaccess/ResourceListPropertiesTabbedPane.java
@@ -465,7 +465,7 @@ which makes up the sort tab.
 
         public void actionPerformed(ActionEvent event)
         {
-            registerChange(new Boolean(((JCheckBox)event.getSource()).isSelected()));
+            registerChange(Boolean.valueOf(((JCheckBox)event.getSource()).isSelected()));
         }
 
         public void itemStateChanged(ItemEvent event)

--- a/src/main/java/com/ibm/as400/vaccess/ResourcePropertiesTabbedPane.java
+++ b/src/main/java/com/ibm/as400/vaccess/ResourcePropertiesTabbedPane.java
@@ -400,7 +400,7 @@ in the properties pane.  It enables the Apply button and records any changes.
 
         public void actionPerformed(ActionEvent event)
         {
-            registerChange(new Boolean(((JCheckBox)event.getSource()).isSelected()));
+            registerChange(Boolean.valueOf(((JCheckBox)event.getSource()).isSelected()));
         }
 
         public void itemStateChanged(ItemEvent event)

--- a/src/main/java/com/ibm/as400/vaccess/SQLQueryBuilderPane.java
+++ b/src/main/java/com/ibm/as400/vaccess/SQLQueryBuilderPane.java
@@ -865,10 +865,10 @@ This property is bound and constrained.
 public void setUserSelectTables (boolean flag)
     throws PropertyVetoException
 {
-    Boolean old = new Boolean(tablesUserDefined_);
+    Boolean old = Boolean.valueOf(tablesUserDefined_);
 
     // Fire a vetoable change event.
-    vetoListeners_.fireVetoableChange("userSelectTables", old, new Boolean(flag));
+    vetoListeners_.fireVetoableChange("userSelectTables", old, Boolean.valueOf(flag));
 
     // Make property change.
     tablesUserDefined_ = flag;
@@ -877,7 +877,7 @@ public void setUserSelectTables (boolean flag)
     tablePane_.setEnabled(flag);
 
     // Fire the property change event.
-    changeListeners_.firePropertyChange("userSelectTables", old, new Boolean(flag));
+    changeListeners_.firePropertyChange("userSelectTables", old, Boolean.valueOf(flag));
 }
 
 
@@ -899,7 +899,7 @@ public void setUserSelectTableSchemas (boolean flag)
 {
     // Fire a vetoable change event.
     vetoListeners_.fireVetoableChange("userSelectTableSchemas",
-           new Boolean(schemasUserDefined_), new Boolean(flag));
+           Boolean.valueOf(schemasUserDefined_), Boolean.valueOf(flag));
 
     // Make property change.
     boolean old = schemasUserDefined_;
@@ -913,7 +913,7 @@ public void setUserSelectTableSchemas (boolean flag)
 
     // Fire the property change event.
     changeListeners_.firePropertyChange("userSelectTableSchemas",
-           new Boolean(old), new Boolean(flag));
+           Boolean.valueOf(old), Boolean.valueOf(flag));
 }
 
 

--- a/src/main/java/com/ibm/as400/vaccess/SpooledFileViewer.java
+++ b/src/main/java/com/ibm/as400/vaccess/SpooledFileViewer.java
@@ -1318,8 +1318,8 @@ in order to load the spooled file and properly initialize the viewer.
 
             // warn of pagesEstimated property change
             vetoableChangeSupport_.fireVetoableChange("numberOfPagesEstimated",
-                                        new Boolean(numberOfPagesEst_),
-                                        new Boolean(newEstimated));
+                                        Boolean.valueOf(numberOfPagesEst_),
+                                        Boolean.valueOf(newEstimated));
 
             // we know the number of pages is estimated
             boolean oldEstimated = numberOfPagesEst_;
@@ -1327,8 +1327,8 @@ in order to load the spooled file and properly initialize the viewer.
 
             // fire numberOfPagesEstimated property change
             propertyChangeSupport_.firePropertyChange("numberOfPagesEstimated",
-                                        new Boolean(oldEstimated),
-                                        new Boolean(numberOfPagesEst_));
+                                        Boolean.valueOf(oldEstimated),
+                                        Boolean.valueOf(numberOfPagesEst_));
 
             // display '*' if the number of pages is estimated
             if (numberOfPagesEst_ == true) {
@@ -1534,8 +1534,8 @@ an error event is fired.
 
                     // warn of property change, only from true to false
                     vetoableChangeSupport_.fireVetoableChange("numberOfPagesEstimated",
-                                        new Boolean(true),
-                                        new Boolean(false));
+                                        Boolean.TRUE,
+                                        Boolean.FALSE);
 
                     // we know the number of pages is valid
                     numberOfPagesEst_ = false;
@@ -1543,8 +1543,8 @@ an error event is fired.
 
                     // fire numberOfPagesEstimated property change, only from true to false
                     propertyChangeSupport_.firePropertyChange("numberOfPagesEstimated",
-                                        new Boolean(true),
-                                        new Boolean(false));
+                                        Boolean.TRUE,
+                                        Boolean.FALSE);
 
                  }
                  // warn of property change

--- a/src/main/java/com/ibm/as400/vaccess/VActionAdapter.java
+++ b/src/main/java/com/ibm/as400/vaccess/VActionAdapter.java
@@ -324,8 +324,8 @@ Sets the enabled state of the action.
 **/
     public void setEnabled (boolean enabled)
     {
-        Boolean oldValue = new Boolean (enabled_);
-        Boolean newValue = new Boolean (enabled);
+        Boolean oldValue = Boolean.valueOf(enabled_);
+        Boolean newValue = Boolean.valueOf(enabled);
 
         enabled_ = enabled;
         if (action_ != null)


### PR DESCRIPTION
Quoting [JDK 8 javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/Boolean.html#Boolean-boolean-):
> Note: It is rarely appropriate to use this constructor. Unless a new instance is required, the static factory [valueOf(boolean)](https://docs.oracle.com/javase/8/docs/api/java/lang/Boolean.html#valueOf-boolean-) is generally a better choice. It is likely to yield significantly better space and time performance.

Also, the constructor is deprecated from Java 9 onwards.

NB: I do not know opinions regarding the autoboxing feature, so I used the `valueOf` method.