### PR TITLE
Provided scope for maven-antrun-plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-antrun-plugin</artifactId>
       <version>3.1.0</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Minor improvement to avoid adding maven-antrun-plugin as a dependency for the library, as it is required only for build