### PR TITLE
remove pre-jdk1.4 workarounds

### DIFF
--- a/archived/jtopenlite/com/ibm/jtopenlite/EncryptPassword.java
+++ b/archived/jtopenlite/com/ibm/jtopenlite/EncryptPassword.java
@@ -46,9 +46,7 @@ final class EncryptPassword
     }
     catch (NoSuchAlgorithmException e)
     {
-      IOException io = new IOException("Error loading SHA encryption: "+e);
-      io.initCause(e);
-      throw io;
+      throw new IOException("Error loading SHA encryption: " + e, e);
     }
   }
 

--- a/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCBlobLocator.java
+++ b/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCBlobLocator.java
@@ -91,9 +91,7 @@ public final class JDBCBlobLocator implements Blob, DatabaseLOBDataCallback
     }
     catch (IOException io)
     {
-      SQLException sql = new SQLException(io.toString());
-      sql.initCause(io);
-      throw sql;
+      throw new SQLException(io);
     }
   }
 
@@ -121,9 +119,7 @@ public final class JDBCBlobLocator implements Blob, DatabaseLOBDataCallback
       }
       catch (IOException io)
       {
-        SQLException sql = new SQLException(io.toString());
-        sql.initCause(io);
-        throw sql;
+        throw new SQLException(io);
       }
     }
     return length_;

--- a/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCClob.java
+++ b/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCClob.java
@@ -81,9 +81,7 @@ public class JDBCClob implements Clob
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 
@@ -98,9 +96,7 @@ public class JDBCClob implements Clob
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 
@@ -119,9 +115,7 @@ public class JDBCClob implements Clob
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 
@@ -159,9 +153,7 @@ public class JDBCClob implements Clob
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 
@@ -199,9 +191,7 @@ public class JDBCClob implements Clob
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 

--- a/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCDriver.java
+++ b/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCDriver.java
@@ -210,9 +210,7 @@ static
     }
     catch (SQLException sql)
     {
-      RuntimeException re = new RuntimeException("Error registering driver: "+sql.toString());
-      re.initCause(sql);
-      throw re;
+      throw new RuntimeException("Error registering driver: "+sql.toString(), sql);
     }
   }
 

--- a/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCResultSet.java
+++ b/archived/jtopenlite/com/ibm/jtopenlite/database/jdbc/JDBCResultSet.java
@@ -1012,9 +1012,7 @@ public class JDBCResultSet implements ResultSet, DatabaseFetchCallback
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 
@@ -1031,9 +1029,7 @@ public class JDBCResultSet implements ResultSet, DatabaseFetchCallback
     }
     catch (UnsupportedEncodingException uee)
     {
-      SQLException sql = new SQLException(uee.toString());
-      sql.initCause(uee);
-      throw sql;
+      throw new SQLException(uee);
     }
   }
 
@@ -1047,9 +1043,7 @@ public class JDBCResultSet implements ResultSet, DatabaseFetchCallback
     }
     catch (MalformedURLException e)
     {
-      SQLException sql = new SQLException("Data conversion error");
-      sql.initCause(e);
-      throw sql;
+      throw new SQLException("Data conversion error", e);
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/AS400.java
+++ b/src/main/java/com/ibm/as400/access/AS400.java
@@ -61,12 +61,10 @@ import com.ibm.as400.security.auth.ProfileTokenProvider;
 public class AS400 implements Serializable, AutoCloseable
 {
     private static final String CLASSNAME = "com.ibm.as400.access.AS400";
-    static boolean jdk14 = false;
     
     static
     {
         if (Trace.traceOn_) Trace.logLoadPath(CLASSNAME);
-        jdk14 = JVMInfo.isJDK14();
     }
 
     static final long serialVersionUID = 4L;
@@ -1928,17 +1926,8 @@ public class AS400 implements Serializable, AutoCloseable
       GregorianCalendar expirationDate = signonInfo_.expirationDate;
       GregorianCalendar now = signonInfo_.currentSignonDate;
       if (expirationDate != null && now != null) {
-        // getTimeInMillis() is protected in JDK 1.3 and cannot be used
-        long lExpiration;
-        long lNow;
-        if (jdk14) {
-          lExpiration = expirationDate.getTimeInMillis();
-          lNow = now.getTimeInMillis();
-        } else {
-          lExpiration = expirationDate.getTime().getTime();
-          lNow = now.getTime().getTime();
-
-        }
+        long lExpiration = expirationDate.getTimeInMillis();
+        long lNow = now.getTimeInMillis();
 
         // Divide by number of seconds in day, round up.
         int days = (int) (((lExpiration - lNow) / 0x5265C00) + 1);

--- a/src/main/java/com/ibm/as400/access/AS400FTP.java
+++ b/src/main/java/com/ibm/as400/access/AS400FTP.java
@@ -313,11 +313,7 @@ public class AS400FTP
              if (Trace.isTraceOn())
                 Trace.log(Trace.DIAGNOSTIC,"Security exception in getVRM()", e);
 
-             IOException throwException = new IOException(e.getMessage());
-             try { 
-               throwException.initCause(e); 
-             } catch (Throwable t) {}
-             throw throwException;
+             throw new IOException(e);
           }
 
           AS400ImplRemote systemImpl = (AS400ImplRemote)system_.getImpl();                               // @D2a
@@ -942,11 +938,7 @@ public class AS400FTP
                {
                   if (Trace.isTraceOn())
                      Trace.log(Trace.DIAGNOSTIC,"IO Exception running command call ", e);
-                  IOException throwException = new IOException(e.getMessage());
-                  try { 
-                    throwException.initCause(e); 
-                  } catch (Throwable t) {}
-                  throw throwException;
+                  throw new IOException(e);
 
                }
 

--- a/src/main/java/com/ibm/as400/access/AS400ImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/AS400ImplRemote.java
@@ -656,10 +656,7 @@ public class AS400ImplRemote implements AS400Impl {
         Trace.log(Trace.ERROR, "Interrupted");
         InterruptedIOException throwException = new InterruptedIOException(
             e.getMessage());
-        try {
-          throwException.initCause(e);
-        } catch (Throwable t) {
-        }
+        throwException.initCause(e);
         throw throwException;
       }
       // Verify that we got a handle back.
@@ -691,10 +688,7 @@ public class AS400ImplRemote implements AS400Impl {
         Trace.log(Trace.ERROR, "Interrupted");
         InterruptedIOException throwException = new InterruptedIOException(
             e.getMessage());
-        try {
-          throwException.initCause(e);
-        } catch (Throwable t) {
-        }
+        throwException.initCause(e);
         throw throwException;
       }
 
@@ -4691,10 +4685,7 @@ public class AS400ImplRemote implements AS400Impl {
 	        Trace.log(Trace.ERROR, "Interrupted");
 	        InterruptedIOException throwException = new InterruptedIOException(
 	            e.getMessage());
-	        try {
-	          throwException.initCause(e);
-	        } catch (Throwable t) {
-	        }
+	        throwException.initCause(e);
 	        throw throwException;
 	      } catch (Throwable e) {
 	          Trace.log(Trace.ERROR, "Error retrieving GSSToken:", e);

--- a/src/main/java/com/ibm/as400/access/AS400JDBCDataSourceBeanInfo.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCDataSourceBeanInfo.java
@@ -831,9 +831,7 @@ enableSeamlessFailover .setShortDescription(AS400JDBCDriver.getResource("ENABLE_
         }
         catch(Exception e)
         { 
-            Error error = new Error(e.toString());
-            error.initCause(e);
-            throw error ;
+            throw new Error(e) ;
         }
     }
 

--- a/src/main/java/com/ibm/as400/access/AS400JDBCInputStream.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCInputStream.java
@@ -288,11 +288,7 @@ exception is thrown.
         //@pdd e.printStackTrace(DriverManager.getLogStream());
         closed_ = true;                                   
       }
-      IOException throwException = new IOException(e.getMessage());
-      try { 
-        throwException.initCause(e); 
-      } catch (Throwable t) {}
-      throw throwException;
+      throw new IOException(e);
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/AS400JDBCOutputStream.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCOutputStream.java
@@ -107,11 +107,7 @@ abstract class AS400JDBCOutputStream extends OutputStream
         JDTrace.logException(this, "Exception caught", e);
       }
       closed_ = true;
-      IOException throwException = new IOException(e.getMessage());
-      try { 
-        throwException.initCause(e); 
-      } catch (Throwable t) {}
-      throw throwException;
+      throw new IOException(e);
 
     }
   }
@@ -144,11 +140,7 @@ abstract class AS400JDBCOutputStream extends OutputStream
         JDTrace.logException(this, "Exception caught", e);
       }
       closed_ = true;
-      IOException throwException = new IOException(e.getMessage());
-      try { 
-        throwException.initCause(e); 
-      } catch (Throwable t) {}
-      throw throwException;
+      throw new IOException(e);
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/AS400JDBCPreparedStatementImpl.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCPreparedStatementImpl.java
@@ -1753,12 +1753,7 @@ public class AS400JDBCPreparedStatementImpl extends AS400JDBCPreparedStatement  
         }
         BatchUpdateException batchUpdateException = new BatchUpdateException(
             e.getMessage(), e.getSQLState(), e.getErrorCode(), counts);
-        // Attempt to set the cause, ignoring any failures (i.e. in Pre JDK 1.4)
-        // /*@DAA*/
-        try {
-          batchUpdateException.initCause(e);
-        } catch (java.lang.NoSuchMethodError e2) {
-        }
+        batchUpdateException.initCause(e);
 
         throw batchUpdateException;
       } finally {

--- a/src/main/java/com/ibm/as400/access/AS400JDBCResultSet.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCResultSet.java
@@ -6075,7 +6075,7 @@ void postWarningSQLState(String sqlState)  {
             
             //if above cannot determine holdability, then do best guess
             if(connection_ instanceof AS400JDBCConnection && connection_ != null)        //@cur
-                return ((AS400JDBCConnection) connection_).getHoldability();             //@cur  CAST needed for JDK 1.3 
+                return connection_.getHoldability();                                     //@cur
             else                                                                         //@cur
                 return ResultSet.CLOSE_CURSORS_AT_COMMIT;                                //@cur (if no statment exists for this, then safest is to return close at commit to prevent cursor reuse errors)
         }

--- a/src/main/java/com/ibm/as400/access/AS400JDBCStatement.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCStatement.java
@@ -2511,9 +2511,7 @@ implements Statement
                 batch_.removeAllElements ();
                 BatchUpdateException throwException = new BatchUpdateException (e.getMessage (),
                     e.getSQLState (), e.getErrorCode (), updateCounts2);
-                try { 
-                  throwException.initCause(e); 
-                } catch (Throwable t) {}
+                throwException.initCause(e);
                 throw throwException;
                 }
 

--- a/src/main/java/com/ibm/as400/access/AS400JDBCWriter.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCWriter.java
@@ -176,11 +176,7 @@ class AS400JDBCWriter extends Writer
         JDTrace.logException(this, "Exception caught", e); 
       }
       closed_ = true;
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 }

--- a/src/main/java/com/ibm/as400/access/AS400JDBCXAResource.java
+++ b/src/main/java/com/ibm/as400/access/AS400JDBCXAResource.java
@@ -964,10 +964,8 @@ specified.
     {
       JDTrace.logException(this, "throwing XAException(XAER_RMFAIL) because of", e); 
     }
-    XAException xaex = new XAException(XAException.XAER_RMFAIL);
-    try { 
-      xaex.initCause(e);
-    } catch (Throwable t) {}
+    XAException xaex = new XAException(XAException.XAER_RMFAIL); 
+    xaex.initCause(e);
     throw xaex; 
   }
 

--- a/src/main/java/com/ibm/as400/access/AS400SecurityException.java
+++ b/src/main/java/com/ibm/as400/access/AS400SecurityException.java
@@ -360,12 +360,8 @@ public class AS400SecurityException extends Exception implements ReturnCodeExcep
     /*@M4A*/
    protected AS400SecurityException(int returnCode, Throwable e)
    {
-       super(ResourceBundleLoader.getText(getMRIKey(returnCode)));
+       super(ResourceBundleLoader.getText(getMRIKey(returnCode)), e);
        rc_ =  returnCode;
-       // Remember the cause of the exception
-       try { 
-         initCause(e); 
-       } catch (Throwable t) { } 
    }
 
     // Constructs an AS400SecurityException object. 

--- a/src/main/java/com/ibm/as400/access/ClassDecoupler.java
+++ b/src/main/java/com/ibm/as400/access/ClassDecoupler.java
@@ -106,10 +106,7 @@ public class ClassDecoupler
           keyPair = DDMTerm.getAESKeyPair();
         }
       } catch (GeneralSecurityException e) {
-        ServerStartupException serverStartupException = new ServerStartupException(
-            ServerStartupException.CONNECTION_NOT_ESTABLISHED);
-        serverStartupException.initCause(e);
-        throw serverStartupException; 
+        throw new ServerStartupException(ServerStartupException.CONNECTION_NOT_ESTABLISHED, e);
       }
     } else {
       requestByteType = byteType_; 
@@ -145,10 +142,7 @@ public class ClassDecoupler
               keyPair = DDMTerm.getAESKeyPair(); 
             }
         } catch (GeneralSecurityException e) {
-          ServerStartupException serverStartupException = new ServerStartupException(
-              ServerStartupException.CONNECTION_NOT_ESTABLISHED);
-          serverStartupException.initCause(e);
-          throw serverStartupException; 
+          throw new ServerStartupException(ServerStartupException.CONNECTION_NOT_ESTABLISHED, e);
         }
 
         ACCSECReq = new DDMACCSECRequestDataStream(aesEncryption, requestByteType, null, keyPair, forceAES); // We currently don't need to pass the IASP to the ACCSEC, but may in the future.
@@ -167,10 +161,7 @@ public class ClassDecoupler
               keyPair = DDMTerm.getAESKeyPair();
               forceAES = true; 
           } catch (GeneralSecurityException e) {
-            ServerStartupException serverStartupException = new ServerStartupException(
-                ServerStartupException.CONNECTION_NOT_ESTABLISHED);
-            serverStartupException.initCause(e);
-            throw serverStartupException; 
+            throw new ServerStartupException(ServerStartupException.CONNECTION_NOT_ESTABLISHED, e);
           }
           
           ACCSECReq = new DDMACCSECRequestDataStream(aesEncryption, requestByteType, null, keyPair, forceAES); // We currently don't need to pass the IASP to the ACCSEC, but may in the future.
@@ -201,10 +192,7 @@ public class ClassDecoupler
                 keyPair = DDMTerm.getAESKeyPair();
                 forceAES = true; 
             } catch (GeneralSecurityException e) {
-              ServerStartupException serverStartupException = new ServerStartupException(
-                  ServerStartupException.CONNECTION_NOT_ESTABLISHED);
-              serverStartupException.initCause(e);
-              throw serverStartupException; 
+              throw new ServerStartupException(ServerStartupException.CONNECTION_NOT_ESTABLISHED, e);
             }
             
             ACCSECReq = new DDMACCSECRequestDataStream(aesEncryption, requestByteType, null, keyPair, forceAES); // We currently don't need to pass the IASP to the ACCSEC, but may in the future.

--- a/src/main/java/com/ibm/as400/access/ConnectionPoolException.java
+++ b/src/main/java/com/ibm/as400/access/ConnectionPoolException.java
@@ -58,13 +58,8 @@ public class ConnectionPoolException extends Exception
   **/
   ConnectionPoolException(Exception exception)
   {
-    super(exception.getMessage());
+    super(exception.getMessage(), exception);
     exception_ = exception;
-    // Remember the cause of the exception
-    // This method does not exist prior to jdk14 
-    try { 
-      initCause(exception); 
-    } catch (Throwable t) { } 
   }
 
   //@A1A

--- a/src/main/java/com/ibm/as400/access/ExtendedIllegalArgumentException.java
+++ b/src/main/java/com/ibm/as400/access/ExtendedIllegalArgumentException.java
@@ -71,13 +71,7 @@ public class ExtendedIllegalArgumentException  extends IllegalArgumentException 
     public ExtendedIllegalArgumentException(String argument, int returnCode, Exception e)
     {
         // Create the message
-  super(argument + ": " + ResourceBundleLoader.getCoreText(getMRIKey(returnCode)));
-  //
-  // Set the cause, catching exception if JDK 1.3 or earlier
-  // 
-  try {
-    initCause(e); 
-  } catch (Throwable t) { }
+  super(argument + ": " + ResourceBundleLoader.getCoreText(getMRIKey(returnCode)), e);
   rc_ =  returnCode;
     }
 

--- a/src/main/java/com/ibm/as400/access/IFSFileBeanInfo.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileBeanInfo.java
@@ -124,9 +124,7 @@ public class IFSFileBeanInfo extends SimpleBeanInfo
      }
     catch(Exception e)
     {
-      Error error = new Error(e.toString());
-      error.initCause(e); 
-      throw error; 
+      throw new Error(e); 
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/IFSFileDescriptorImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileDescriptorImplRemote.java
@@ -167,9 +167,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -274,9 +272,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
     if (ds instanceof IFSReturnCodeRep)
@@ -357,9 +353,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -461,9 +455,7 @@ implements IFSFileDescriptorImpl
                   system_.disconnectServer(server_);
                   server_ = null;
                   InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-                  try {
-                    throwException.initCause(e); 
-                  } catch (Throwable t) {} 
+                  throwException.initCause(e);
                   throw throwException;
               }
               catch(IOException e)
@@ -613,9 +605,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -766,9 +756,7 @@ implements IFSFileDescriptorImpl
         {
           Trace.log(Trace.ERROR, "Interrupted");
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
 
@@ -925,9 +913,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -985,9 +971,7 @@ implements IFSFileDescriptorImpl
         {
           Trace.log(Trace.ERROR, "Interrupted");
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
       }
@@ -1147,9 +1131,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -1242,9 +1224,7 @@ implements IFSFileDescriptorImpl
       {
         Trace.log(Trace.ERROR, "Interrupted", e);
         InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
+        throwException.initCause(e);
         throw throwException;
       }
 
@@ -1317,9 +1297,7 @@ implements IFSFileDescriptorImpl
           {
             Trace.log(Trace.ERROR, "Interrupted", e);
             InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-            try {
-              throwException.initCause(e); 
-            } catch (Throwable t) {} 
+            throwException.initCause(e);
             throw throwException;
           }
         }
@@ -1396,9 +1374,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
     finally {
@@ -1550,9 +1526,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -1642,9 +1616,7 @@ implements IFSFileDescriptorImpl
       {
         Trace.log(Trace.ERROR, "Interrupted", e);
         InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
+        throwException.initCause(e);
         throw throwException;
       }
 
@@ -1714,9 +1686,7 @@ implements IFSFileDescriptorImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
     // Verify that we got a handle back.
@@ -1754,9 +1724,7 @@ implements IFSFileDescriptorImpl
     } catch (InterruptedException e) {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -1841,9 +1809,7 @@ implements IFSFileDescriptorImpl
         {
           Trace.log(Trace.ERROR, "Interrupted");
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
 
@@ -1924,9 +1890,7 @@ implements IFSFileDescriptorImpl
       {
         Trace.log(Trace.ERROR, "Interrupted");
         InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
+        throwException.initCause(e);
         throw throwException;
       }
 
@@ -2005,9 +1969,7 @@ implements IFSFileDescriptorImpl
         {
           Trace.log(Trace.ERROR, "Interrupted");
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
 
@@ -2054,7 +2016,7 @@ implements IFSFileDescriptorImpl
           Trace.log(Trace.ERROR, "Interrupted");
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
           try {
-            throwException.initCause(e); 
+            throwException.initCause(e);
           } catch (Throwable t) {} 
           throw throwException;
         }
@@ -2133,9 +2095,7 @@ implements IFSFileDescriptorImpl
 	        {
 	          Trace.log(Trace.ERROR, "Interrupted");
 	          InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-	          try {
-	            throwException.initCause(e); 
-	          } catch (Throwable t) {} 
+	          throwException.initCause(e);
 	          throw throwException;
 	        }
 

--- a/src/main/java/com/ibm/as400/access/IFSFileImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileImplRemote.java
@@ -530,12 +530,7 @@ implements IFSFileImpl
         if (e instanceof IOException) { 
            throw (IOException) e;
         } else {
-           IOException ioEx = new IOException(e.toString());
-           // initCause was added in JDK 1.4.  Ignore exception if it does not exist. 
-           try {
-             ioEx.initCause(e); 
-           } catch (Throwable e2) {} 
-           throw ioEx;
+           throw new IOException(e);
         }
       }
     }
@@ -556,9 +551,7 @@ implements IFSFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -863,9 +856,7 @@ implements IFSFileImpl
       {
         Trace.log(Trace.ERROR, "Interrupted");
         InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
+        throwException.initCause(e);
         throw throwException;
       }
 
@@ -912,9 +903,7 @@ implements IFSFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -2235,9 +2224,7 @@ implements IFSFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -2343,9 +2330,7 @@ implements IFSFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -2434,9 +2419,7 @@ implements IFSFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -2509,9 +2492,7 @@ implements IFSFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted");
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -2613,9 +2594,7 @@ implements IFSFileImpl
           {
              Trace.log(Trace.ERROR, "Interrupted");
              InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-             try {
-               throwException.initCause(e); 
-             } catch (Throwable t) {} 
+             throwException.initCause(e);
              throw throwException;
           }
 
@@ -2735,9 +2714,7 @@ implements IFSFileImpl
         {
           Trace.log(Trace.ERROR, "Interrupted");
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
 
@@ -2908,9 +2885,7 @@ implements IFSFileImpl
           {
              Trace.log(Trace.ERROR, "Interrupted");
              InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-             try {
-               throwException.initCause(e); 
-             } catch (Throwable t) {} 
+             throwException.initCause(e);
              throw throwException;
           }
 

--- a/src/main/java/com/ibm/as400/access/IFSFileInputStream.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileInputStream.java
@@ -779,8 +779,7 @@ public class IFSFileInputStream extends InputStream
   {
     if (fd_.isClosed()) {
       Trace.log(Trace.ERROR, "The stream has been closed.");
-      //throw new java.nio.channels.ClosedChannelException();  // requires JDK 1.4
-      throw new IOException();
+      throw new java.nio.channels.ClosedChannelException();
     }
     rewind();
   }

--- a/src/main/java/com/ibm/as400/access/IFSFileInputStreamImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileInputStreamImplRemote.java
@@ -150,9 +150,7 @@ implements IFSFileInputStreamImpl
     {
       Trace.log(Trace.ERROR, "Interrupted.", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -201,9 +199,7 @@ implements IFSFileInputStreamImpl
         {
           Trace.log(Trace.ERROR, "Interrupted", e);
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
       }
@@ -249,11 +245,7 @@ implements IFSFileInputStreamImpl
       return fd_.lock(length);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -320,9 +312,7 @@ implements IFSFileInputStreamImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -431,11 +421,7 @@ implements IFSFileInputStreamImpl
       return fd_.read(data, dataOffset, length);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -554,11 +540,7 @@ implements IFSFileInputStreamImpl
       fd_.unlock(key);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/IFSFileOutputStream.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileOutputStream.java
@@ -642,8 +642,7 @@ public class IFSFileOutputStream extends OutputStream
   {
     if (fd_.isClosed()) {
       Trace.log(Trace.ERROR, "The stream has been closed.");
-      //throw new java.nio.channels.ClosedChannelException();  // requires JDK 1.4
-      throw new IOException();
+      throw new java.nio.channels.ClosedChannelException();
     }
 
     // Ensure that the file is open.

--- a/src/main/java/com/ibm/as400/access/IFSFileOutputStreamImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileOutputStreamImplRemote.java
@@ -113,11 +113,7 @@ implements IFSFileOutputStreamImpl
         fd_.flush();  // @B4a
       }
       catch (AS400SecurityException e) {
-        IOException throwException = new IOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
-        throw throwException;
+        throw new IOException(e);
       }
   }
 
@@ -145,11 +141,7 @@ implements IFSFileOutputStreamImpl
       return fd_.lock(length);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -224,9 +216,7 @@ implements IFSFileOutputStreamImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -313,11 +303,7 @@ implements IFSFileOutputStreamImpl
       fd_.unlock(key);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -394,9 +380,7 @@ implements IFSFileOutputStreamImpl
       {
         Trace.log(Trace.ERROR, "Interrupted", e);
         InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
+        throwException.initCause(e);
         throw throwException;
       }
 
@@ -431,11 +415,7 @@ implements IFSFileOutputStreamImpl
       fd_.writeBytes(data, dataOffset, length);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -534,9 +514,7 @@ implements IFSFileOutputStreamImpl
               {
                 Trace.log(Trace.ERROR, "Interrupted");
                 InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-                try {
-                  throwException.initCause(e); 
-                } catch (Throwable t) {} 
+                throwException.initCause(e);
                 throw throwException;
               }
             }
@@ -558,9 +536,7 @@ implements IFSFileOutputStreamImpl
         {
           Trace.log(Trace.ERROR, "Interrupted", e);
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
 

--- a/src/main/java/com/ibm/as400/access/IFSJavaFile.java
+++ b/src/main/java/com/ibm/as400/access/IFSJavaFile.java
@@ -330,12 +330,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (IOException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
-
+      throw new SecurityException(e);
     }
   }
 
@@ -357,11 +352,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (IOException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
   }
 
@@ -382,11 +373,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (IOException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
   }
 
@@ -552,11 +539,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -614,11 +597,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -723,11 +702,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -753,11 +728,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -787,11 +758,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -992,11 +959,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1029,11 +992,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1060,11 +1019,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
      }
      catch (AS400SecurityException e)
      {
-       SecurityException throwException = new SecurityException(e.getMessage());
-       try {
-         throwException.initCause(e); 
-       } catch (Throwable t) {} 
-       throw throwException;
+       throw new SecurityException(e);
      }
      catch (IOException e)
      {
@@ -1092,11 +1047,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1129,11 +1080,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1164,11 +1111,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1224,11 +1167,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1305,11 +1244,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1352,11 +1287,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1395,11 +1326,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1480,11 +1407,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1570,11 +1493,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1695,11 +1614,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1794,11 +1709,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1828,11 +1739,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -1871,11 +1778,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (PropertyVetoException e) {}  // will never happen
     catch (IOException e)
@@ -1931,11 +1834,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
      catch (AS400SecurityException e)
      {
        Trace.log(Trace.ERROR, e);
-       SecurityException throwException = new SecurityException(e.getMessage());
-       try {
-         throwException.initCause(e); 
-       } catch (Throwable t) {} 
-       throw throwException;
+       throw new SecurityException(e);
      }
      catch (IOException e)
      {
@@ -1964,11 +1863,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
      catch (AS400SecurityException e)
      {
        Trace.log(Trace.ERROR, e);
-       SecurityException throwException = new SecurityException(e.getMessage());
-       try {
-         throwException.initCause(e); 
-       } catch (Throwable t) {} 
-       throw throwException;
+       throw new SecurityException(e);
      }
      catch (IOException e)
      {
@@ -2037,11 +1932,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
      catch (AS400SecurityException e)
      {
        Trace.log(Trace.ERROR, e);
-       SecurityException throwException = new SecurityException(e.getMessage());
-       try {
-         throwException.initCause(e); 
-       } catch (Throwable t) {} 
-       throw throwException;
+       throw new SecurityException(e);
      }
      catch (IOException e)
      {
@@ -2113,11 +2004,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -2164,11 +2051,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {
@@ -2215,11 +2098,7 @@ public class IFSJavaFile extends java.io.File implements java.io.Serializable
     catch (AS400SecurityException e)
     {
       Trace.log(Trace.ERROR, e);
-      SecurityException throwException = new SecurityException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new SecurityException(e);
     }
     catch (IOException e)
     {

--- a/src/main/java/com/ibm/as400/access/IFSRandomAccessFileImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/IFSRandomAccessFileImplRemote.java
@@ -111,11 +111,7 @@ implements IFSRandomAccessFileImpl
       fd_.flush();  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -173,9 +169,7 @@ implements IFSRandomAccessFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e);
       throw throwException;
     }
 
@@ -224,9 +218,7 @@ implements IFSRandomAccessFileImpl
         {
           Trace.log(Trace.ERROR, "Interrupted", e);
           InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
+          throwException.initCause(e);
           throw throwException;
         }
       }
@@ -270,11 +262,7 @@ implements IFSRandomAccessFileImpl
       return fd_.lock(offset,length);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -361,9 +349,7 @@ implements IFSRandomAccessFileImpl
     {
       Trace.log(Trace.ERROR, "Interrupted", e);
       InterruptedIOException throwException = new InterruptedIOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
+      throwException.initCause(e); 
       throw throwException;
     }
 
@@ -508,11 +494,7 @@ implements IFSRandomAccessFileImpl
       }
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -533,11 +515,7 @@ implements IFSRandomAccessFileImpl
         readCacheLength_ = read(readCache_, 0, readCache_.length);
       }
       catch (AS400SecurityException e) {
-        IOException throwException = new IOException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
-        throw throwException;
+        throw new IOException(e);
       }
       if (readCacheLength_ == -1)
       {
@@ -727,11 +705,7 @@ implements IFSRandomAccessFileImpl
       return sb.toString();
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -811,11 +785,7 @@ implements IFSRandomAccessFileImpl
       fd_.setLength(length);
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -863,11 +833,7 @@ implements IFSRandomAccessFileImpl
       fd_.unlock(key);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 
@@ -898,11 +864,7 @@ implements IFSRandomAccessFileImpl
       fd_.writeBytes(data, dataOffset, length, forceToStorage_);  // @B2C
     }
     catch (AS400SecurityException e) {
-      IOException throwException = new IOException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IOException(e);
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/IFSSystemView.java
+++ b/src/main/java/com/ibm/as400/access/IFSSystemView.java
@@ -131,21 +131,6 @@ public class IFSSystemView extends FileSystemView
       else return file;
     }
 
-
-    // Note: The method createFileSystemRoot() was added to the FileSystemView class in JDK 1.4.
-    // We provide an implementation here to swallow the NoSuchMethodError if running on an older JDK.
-    protected File createFileSystemRoot(File f) {
-      try {
-        return super.createFileSystemRoot(f);
-      }
-      catch (NoSuchMethodError e) {  // method added in JDK 1.4
-        if (Trace.isTraceOn()) {
-          Trace.log(Trace.DIAGNOSTIC, e);
-        }
-        return f;
-      }
-    }
-
     /**
      Creates a new folder with a default name.
      <br>Note: In the context of this class, "folder" is synonymous with "directory".

--- a/src/main/java/com/ibm/as400/access/InternalErrorException.java
+++ b/src/main/java/com/ibm/as400/access/InternalErrorException.java
@@ -142,16 +142,7 @@ implements ReturnCodeException {
       instead 
     **/
     InternalErrorException(int returnCode, String text, Throwable exception) {
-        super(loader_.getText(getMRIKey(returnCode)) + " " + text);
-        //
-        // Set the cause, catching the error if not JDK 1.4
-        // 
-        if (exception != null) { 
-        try {
-          initCause(exception); 
-        } catch (Throwable t) { 
-        }
-        }
+        super(loader_.getText(getMRIKey(returnCode)) + " " + text, exception);
         rc_ = returnCode;
     }
 
@@ -164,14 +155,7 @@ implements ReturnCodeException {
                  Note: This parameter does not get translated.
   **/
   InternalErrorException(int returnCode, Throwable exception ) {
-      super(loader_.getText(getMRIKey(returnCode)) + " " + exception.getMessage());
-      //
-      // Set the cause, catching the error if not JDK 1.4
-      //
-      try {
-        initCause(exception); 
-      } catch (Throwable t) { 
-      }
+      super(loader_.getText(getMRIKey(returnCode)) + " " + exception.getMessage(), exception);
       rc_ = returnCode;
   }
 

--- a/src/main/java/com/ibm/as400/access/JDCallableStatementProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDCallableStatementProxy.java
@@ -892,12 +892,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (parameterValue);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
-
+              throw new SQLException(e);
             }
         }
         callMethod ("setAsciiStream",
@@ -938,11 +933,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (parameterValue);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBinaryStream",
@@ -1012,11 +1003,7 @@ implements CallableStatement
                             Integer.valueOf(length)});
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -1476,11 +1463,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setAsciiStream",
@@ -1503,11 +1486,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBinaryStream",
@@ -1546,11 +1525,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (inputStream);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBlob",
@@ -1578,11 +1553,7 @@ implements CallableStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -1619,11 +1590,7 @@ implements CallableStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -1644,11 +1611,7 @@ implements CallableStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -1688,11 +1651,7 @@ implements CallableStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -1742,11 +1701,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setAsciiStream",
@@ -1767,11 +1722,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBinaryStream",
@@ -1792,11 +1743,7 @@ implements CallableStatement
                 iStream = new SerializableInputStream (inputStream);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBlob",
@@ -1820,11 +1767,7 @@ implements CallableStatement
                     serialRreader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }    
     }
 
@@ -1843,11 +1786,7 @@ implements CallableStatement
                     serialRreader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }    
     }
 
@@ -1866,11 +1805,7 @@ implements CallableStatement
                     serialRreader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }    
     }
 
@@ -1889,11 +1824,7 @@ implements CallableStatement
                     serialRreader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }    
     }
     

--- a/src/main/java/com/ibm/as400/access/JDConnectionProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDConnectionProxy.java
@@ -650,22 +650,18 @@ implements Connection
         if (JDTrace.isTraceOn ()) {
           JDTrace.logException(this, "Security Exception caught", e); 
         }
-        SQLException sqlex = new SQLException (
+        throw new SQLException (
                 AS400JDBCDriver.getResource("JD" + EXC_CONNECTION_REJECTED,null),
-                EXC_CONNECTION_REJECTED, -99999);
-        sqlex.initCause(e); 
-        throw sqlex; 
+                EXC_CONNECTION_REJECTED, -99999, e);
       }
       catch (java.io.IOException e) {                                //@A0C
         // Avoid dragging in JDError:
         if (JDTrace.isTraceOn ()) {
           JDTrace.logException(this,  "IOException caught", e); 
         }
-        SQLException sqlex = new SQLException (
+        throw new SQLException (
                 AS400JDBCDriver.getResource("JD" + EXC_CONNECTION_UNABLE,null),
-                EXC_CONNECTION_UNABLE, -99999);
-        sqlex.initCause(e); 
-        throw sqlex; 
+                EXC_CONNECTION_UNABLE, -99999, e);
       }
     }
         else

--- a/src/main/java/com/ibm/as400/access/JDError.java
+++ b/src/main/java/com/ibm/as400/access/JDError.java
@@ -103,11 +103,6 @@ final class JDError
   // threads are running @Q4D
   // static String       lastServerSQLState_             = null;
 
-  static boolean jdk14 = false;
-  static {
-    jdk14 = JVMInfo.isJDK14();
-  }
-
 /**
 Private constructor to prevent instantiation.  All methods in
 this class are static.
@@ -626,12 +621,10 @@ trace for debugging purposes.
     }                                                                   // @J3a
 
     //
-    // Set the cause for JDK 1.4 and later
+    // Set the cause
     //
-    if (jdk14) {
-      if (e != null) { 
-    	  e2.initCause(e);
-      }
+    if (e != null) { 
+      e2.initCause(e);
     }
     throw e2;
   }

--- a/src/main/java/com/ibm/as400/access/JDPreparedStatementProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDPreparedStatementProxy.java
@@ -189,11 +189,7 @@ implements PreparedStatement
           iStream = new SerializableInputStream (parameterValue);
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
       }
       callMethod ("setAsciiStream",
@@ -231,11 +227,7 @@ implements PreparedStatement
           iStream = new SerializableInputStream (parameterValue);
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
       }
       callMethod ("setBinaryStream",
@@ -321,11 +313,7 @@ implements PreparedStatement
                                    Integer.valueOf(length) });
       }
       catch (java.io.IOException e) {
-        SQLException throwException = new SQLException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
-        throw throwException;
+        throw new SQLException(e);
       }
     }
 
@@ -619,11 +607,7 @@ implements PreparedStatement
           iStream = new SerializableInputStream (parameterValue);
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
       }
       callMethod ("setUnicodeStream",
@@ -682,11 +666,7 @@ implements PreparedStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -729,11 +709,7 @@ implements PreparedStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -749,11 +725,7 @@ implements PreparedStatement
                 iStream = new SerializableInputStream (inputStream);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBlob",
@@ -781,11 +753,7 @@ implements PreparedStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -827,11 +795,7 @@ implements PreparedStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setAsciiStream",
@@ -854,11 +818,7 @@ implements PreparedStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBinaryStream",
@@ -886,11 +846,7 @@ implements PreparedStatement
                     Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -906,11 +862,7 @@ implements PreparedStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setAsciiStream",
@@ -932,11 +884,7 @@ implements PreparedStatement
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBinaryStream",
@@ -958,11 +906,7 @@ implements PreparedStatement
                 iStream = new SerializableInputStream (inputStream);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("setBlob",
@@ -987,11 +931,7 @@ implements PreparedStatement
                     serialReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -1011,11 +951,7 @@ implements PreparedStatement
                     serialReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -1035,11 +971,7 @@ implements PreparedStatement
                     serialReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -1059,11 +991,7 @@ implements PreparedStatement
                     serialReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     

--- a/src/main/java/com/ibm/as400/access/JDResultSetProxy.java
+++ b/src/main/java/com/ibm/as400/access/JDResultSetProxy.java
@@ -1251,11 +1251,7 @@ implements ResultSet
           iStream = new SerializableInputStream (columnValue);
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
       }
       callMethod ("updateAsciiStream",
@@ -1315,11 +1311,7 @@ implements ResultSet
           iStream = new SerializableInputStream (columnValue);
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
       }
       callMethod ("updateBinaryStream",
@@ -1448,11 +1440,7 @@ implements ResultSet
                                    reader, Integer.valueOf(length) });
       }
       catch (java.io.IOException e) {
-        SQLException throwException = new SQLException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
-        throw throwException;
+        throw new SQLException(e);
       }
     }
 
@@ -2010,11 +1998,7 @@ implements ResultSet
                     reader, Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
         
     }
@@ -2108,11 +2092,7 @@ implements ResultSet
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("updateAsciiStream",
@@ -2142,11 +2122,7 @@ implements ResultSet
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("updateBinaryStream",
@@ -2174,11 +2150,7 @@ implements ResultSet
                 iStream = new SerializableInputStream (inputStream);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("updateBlob",
@@ -2210,11 +2182,7 @@ implements ResultSet
                     reader, Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -2239,11 +2207,7 @@ implements ResultSet
                     sReader, Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -2270,11 +2234,7 @@ implements ResultSet
                     sReader, Long.valueOf(length) });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
     
@@ -2303,11 +2263,7 @@ implements ResultSet
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("updateAsciiStream",
@@ -2335,11 +2291,7 @@ implements ResultSet
                 iStream = new SerializableInputStream (x);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("updateBinaryStream",
@@ -2368,11 +2320,7 @@ implements ResultSet
                 iStream = new SerializableInputStream (inputStream);
             }
             catch (java.io.IOException e) {
-              SQLException throwException = new SQLException(e.getMessage());
-              try {
-                throwException.initCause(e); 
-              } catch (Throwable t) {} 
-              throw throwException;
+              throw new SQLException(e);
             }
         }
         callMethod ("updateBlob",
@@ -2403,11 +2351,7 @@ implements ResultSet
                     new Object[] { Integer.valueOf(columnIndex), sReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -2433,11 +2377,7 @@ implements ResultSet
                     new Object[] { Integer.valueOf(columnIndex), sReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 
@@ -2462,11 +2402,7 @@ implements ResultSet
                     new Object[] { Integer.valueOf(columnIndex), sReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
         
     }
@@ -2491,11 +2427,7 @@ implements ResultSet
                     new Object[] { Integer.valueOf(columnIndex), sReader });
         }
         catch (java.io.IOException e) {
-          SQLException throwException = new SQLException(e.getMessage());
-          try {
-            throwException.initCause(e); 
-          } catch (Throwable t) {} 
-          throw throwException;
+          throw new SQLException(e);
         }
     }
 

--- a/src/main/java/com/ibm/as400/access/JVMInfo.java
+++ b/src/main/java/com/ibm/as400/access/JVMInfo.java
@@ -21,35 +21,24 @@ public class JVMInfo
 {
 
   static String javaVersion = null;
-  static boolean jdk14;
   static boolean jdk16;
 
   protected static void initializeJavaVersion() {
     String version = System.getProperty("java.version");
     if (version != null) {
       if (version.length() > 2) {
-        if (version.charAt(0) == '1' && version.charAt(2) < '4') {
-          jdk14 = false;
+        if (version.charAt(0) == '1' && version.charAt(2) < '6') {
           jdk16 = false;
         } else {
-          if (version.charAt(0) == '1' && version.charAt(2) < '6') {
-            jdk14 = true;
-            jdk16 = false;
-          } else {
-            jdk14 = true;
-            jdk16 = true;
-
-          }
+          jdk16 = true;
         }
       } else {
         // Android JVM returns 0 and runs with JDK 1.5
         if ("0".equals(version)) {
-          jdk14 = true;
           jdk16 = false;
         }
         // Java 9 return 9 
         if ("9".equals(version)) {
-          jdk14 = true;
           jdk16 = true;
         }
       }
@@ -57,16 +46,6 @@ public class JVMInfo
 
 
 
-  }
-
-  /*
-   * Is the JVM running JDK 1.4 or later.
-   */
-  public static boolean isJDK14() {
-    if (javaVersion == null) {
-      initializeJavaVersion();
-    }
-    return jdk14;
   }
 
   /*

--- a/src/main/java/com/ibm/as400/access/JavaProgram.java
+++ b/src/main/java/com/ibm/as400/access/JavaProgram.java
@@ -162,11 +162,7 @@ public class JavaProgram implements Serializable
       catch (Exception e) {
         if (Trace.isTraceOn())
           Trace.log(Trace.ERROR, "Error when checking system VRM.", e);
-        UnsupportedOperationException throwException = new UnsupportedOperationException(e.getMessage());
-        try {
-          throwException.initCause(e); 
-        } catch (Throwable t) {} 
-        throw throwException;
+        throw new UnsupportedOperationException(e);
 
       }
     }

--- a/src/main/java/com/ibm/as400/access/JobDescription.java
+++ b/src/main/java/com/ibm/as400/access/JobDescription.java
@@ -300,11 +300,7 @@ public class JobDescription implements Serializable
     catch (RuntimeException e) { throw e; }
     catch (Exception e) {
       Trace.log(Trace.ERROR, "Exception rethrown by loadInformation():", e);
-      IllegalStateException throwException = new IllegalStateException(e.getMessage());
-      try {
-        throwException.initCause(e); 
-      } catch (Throwable t) {} 
-      throw throwException;
+      throw new IllegalStateException(e);
     }
   }
 

--- a/src/main/java/com/ibm/as400/access/JobQueue.java
+++ b/src/main/java/com/ibm/as400/access/JobQueue.java
@@ -188,11 +188,7 @@ public class JobQueue implements Serializable {
 	    catch (RuntimeException e) { throw e; }
 	    catch (Exception e) {
 	      Trace.log(Trace.ERROR, "Exception rethrown by loadInformation():", e);
-	      IllegalStateException throwException = new IllegalStateException(e.getMessage());
-	      try {
-	        throwException.initCause(e); 
-	      } catch (Throwable t) {} 
-	      throw throwException;
+	      throw new IllegalStateException(e);
 	    }
 	  }
 	  

--- a/src/main/java/com/ibm/as400/access/ProxyClientConnection.java
+++ b/src/main/java/com/ibm/as400/access/ProxyClientConnection.java
@@ -330,8 +330,7 @@ class ProxyClientConnection extends PxClientConnectionAdapter
             throw (Error)e2;
         }
         
-        InternalErrorException ex = new InternalErrorException(InternalErrorException.UNEXPECTED_EXCEPTION);
-        ex.initCause(e2);
+        InternalErrorException ex = new InternalErrorException(InternalErrorException.UNEXPECTED_EXCEPTION, e2);
         if (Trace.isTraceProxyOn()) {
           Trace.log(Trace.PROXY, "rethrow @", ex);
         }

--- a/src/main/java/com/ibm/as400/access/ProxyException.java
+++ b/src/main/java/com/ibm/as400/access/ProxyException.java
@@ -109,9 +109,8 @@ Constructs a ProxyException object.
     **/
         ProxyException (int returnCode, Throwable e)
         {
-            super (ResourceBundleLoader.getText (getMRIKey (returnCode)));
+            super (ResourceBundleLoader.getText (getMRIKey (returnCode)), e);
             returnCode_ = returnCode;
-            initCause(e); 
         }
 
 

--- a/src/main/java/com/ibm/as400/access/PxReturnRepCV.java
+++ b/src/main/java/com/ibm/as400/access/PxReturnRepCV.java
@@ -64,9 +64,7 @@ Processes the reply.
         catch (Exception e) {
             if (Trace.isTraceErrorOn ())
                 Trace.log (Trace.ERROR, e.getMessage (), e);
-             InternalErrorException iee = new InternalErrorException (InternalErrorException.PROTOCOL_ERROR);
-            iee.initCause(e); 
-            throw iee;
+            throw new InternalErrorException (InternalErrorException.PROTOCOL_ERROR, e);
         }
     }
       

--- a/src/main/java/com/ibm/as400/access/PxSerializedObjectParm.java
+++ b/src/main/java/com/ibm/as400/access/PxSerializedObjectParm.java
@@ -153,11 +153,7 @@ Loads this datastream by reading from an input stream.
         catch (ClassNotFoundException e) {
             if (Trace.isTraceErrorOn())
                 Trace.log(Trace.ERROR, "Class for deserializing not found", e);
-            IOException throwException =new IOException ("Class not found:" + e.getMessage ());
-            try {
-              throwException.initCause(e); 
-            } catch (Throwable t) {} 
-            throw throwException;  
+            throw new IOException("Class not found:" + e.getMessage (), e);  
         }
     }
 

--- a/src/main/java/com/ibm/as400/access/SQLDate.java
+++ b/src/main/java/com/ibm/as400/access/SQLDate.java
@@ -36,11 +36,6 @@ extends SQLDataBase
 {
     static final String copyright = "Copyright (C) 1997-2002 International Business Machines Corporation and others.";
 
-    static boolean jdk14 = false;
-    static {
-      jdk14 = JVMInfo.isJDK14();
-    }
-
     // Private data.
     private int			    dateFormat_;	// @550A
     private int                     year_;
@@ -185,8 +180,7 @@ extends SQLDataBase
 
         try //@dat1
         {
-        	long millis;
-        	if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        	long millis = calendar.getTimeInMillis();
             return new Date(millis);
         }catch(Exception e){
             if (JDTrace.isTraceOn()) JDTrace.logException((Object)null, "Error parsing date "+s, e); //@dat1
@@ -658,8 +652,7 @@ endif */
 
         calendar.set(year_, month_, day_, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         return new Date(millis);
     }
 
@@ -712,8 +705,7 @@ endif */
         Calendar calendar = AS400Calendar.getGregorianInstance();
         calendar.set(year_, month_, day_, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         Date d = new Date(millis);
         return dateToString(d, settings_, calendar);
     }
@@ -736,8 +728,7 @@ endif */
 
         calendar.set(year_, month_, day_, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         Timestamp ts = new Timestamp(millis);
         ts.setNanos(0);
         return ts;
@@ -751,8 +742,7 @@ endif */
         Calendar calendar = AS400Calendar.getGregorianInstance();
         calendar.set(year_, month_, day_, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         Date d = new Date(millis);
         return dateToString(d, settings_, calendar);
     }

--- a/src/main/java/com/ibm/as400/access/SQLTime.java
+++ b/src/main/java/com/ibm/as400/access/SQLTime.java
@@ -39,11 +39,6 @@ extends SQLDataBase
 {
     static final String copyright = "Copyright (C) 1997-2001 International Business Machines Corporation and others.";
 
-    static boolean jdk14 = false;
-    static {
-      jdk14 = JVMInfo.isJDK14();
-    }
-
     // Private data.
     private int			    timeFormat_;
     private int                     hour_;
@@ -153,9 +148,7 @@ extends SQLDataBase
 
         try //@dat1
         {
-          long millis;
-          if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
-
+          long millis = calendar.getTimeInMillis();
             return new Time(millis);
         }catch(Exception e){
             if (JDTrace.isTraceOn()) JDTrace.logException((Object)null, "Error parsing time "+s, e); //@dat1
@@ -173,12 +166,7 @@ extends SQLDataBase
         lt.getSecond());
     calendar.set(Calendar.MILLISECOND, 0); // @F2A
 
-    long millis;
-    if (jdk14) {
-      millis = calendar.getTimeInMillis();
-    } else {
-      millis = calendar.getTime().getTime();
-    }
+    long millis = calendar.getTimeInMillis();
     Time t = new Time(millis);
 
     return timeToString(t, dataFormat, calendar0, -1); // @E3C
@@ -640,8 +628,7 @@ extends SQLDataBase
         Calendar calendar = AS400Calendar.getGregorianInstance();
         calendar.set(1970, Calendar.JANUARY, 1, hour_, minute_, second_);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
 
         return new Time(millis);
     }
@@ -660,8 +647,7 @@ extends SQLDataBase
         Calendar calendar = AS400Calendar.getGregorianInstance();
         calendar.set(1970, Calendar.JANUARY, 1, hour_, minute_, second_);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         Time t = new Time(millis);
         return timeToString(t, settings_, calendar, hour_);        // @E3C
     }
@@ -687,8 +673,7 @@ extends SQLDataBase
         // SQL Time objects do not track this field.
         calendar.set(Calendar.MILLISECOND, 0);  // @F2A
 
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         return new Time(millis);
     }
 
@@ -715,8 +700,7 @@ extends SQLDataBase
 
         calendar.set(1970, Calendar.JANUARY, 1, hour_, minute_, second_);               //@54A
         calendar.set(Calendar.MILLISECOND, 0);                                          //@54A
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         Timestamp ts = new Timestamp(millis);                     //@54A
         ts.setNanos(0);                                                                 //@54A
         return ts;                                                                      //@54A
@@ -733,8 +717,7 @@ extends SQLDataBase
         Calendar calendar = AS400Calendar.getGregorianInstance();
         calendar.set(1970, Calendar.JANUARY, 1, hour_, minute_, second_);
         calendar.set(Calendar.MILLISECOND, 0);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         Time t = new Time(millis);
         return timeToString(t, settings_, calendar, hour_);        // @E3C
     }

--- a/src/main/java/com/ibm/as400/access/SQLTimestamp.java
+++ b/src/main/java/com/ibm/as400/access/SQLTimestamp.java
@@ -34,10 +34,6 @@ final class SQLTimestamp
 extends SQLDataBase
 {
     static final String copyright2 = "Copyright (C) 1997-2013 International Business Machines Corporation and others.";
-    static boolean jdk14 = false;
-    static {
-      jdk14 = JVMInfo.isJDK14();
-    }
 
     // Private data.
     private int                     year_;
@@ -206,8 +202,7 @@ extends SQLDataBase
             Timestamp ts = null;//@dat1
             try //@dat1
             {
-              long millis;
-              if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+                long millis = calendar.getTimeInMillis();
                 if (picos % 1000 == 0) {   //@H3A
                   ts = new Timestamp(millis); //@dat1
                   ts.setNanos((int)(picos / 1000)); 
@@ -257,12 +252,7 @@ extends SQLDataBase
 
     calendar.set(ldt.getYear(), ldt.getMonthValue() -1 , ldt.getDayOfMonth(),
         ldt.getHour(), ldt.getMinute(), ldt.getSecond());
-    long millis;
-    if (jdk14) {
-      millis = calendar.getTimeInMillis();
-    } else {
-      millis = calendar.getTime().getTime();
-    }
+    long millis = calendar.getTimeInMillis();
 
     Timestamp ts = new Timestamp(millis);
     ts.setNanos(ldt.getNano());
@@ -733,8 +723,7 @@ extends SQLDataBase
 
         calendar.set(year_, month_, day_, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);      //@KBA  added per JTOpen Bug 3818.  According to java.sql.Date, the milliseconds also need to be 'normalized' to zero.
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         return new Date(millis);
     }
 
@@ -772,8 +761,7 @@ extends SQLDataBase
         truncated_ = 0; outOfBounds_ = false;
         Calendar calendar = AS400Calendar.getGregorianInstance();
         calendar.set(year_, month_, day_, hour_, minute_, second_);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         if (picos_ % 1000 == 0) { 
           Timestamp ts = new Timestamp (millis);
           ts.setNanos((int)(picos_ / 1000));
@@ -817,8 +805,7 @@ extends SQLDataBase
         /* 
         Calendar calendar = AS400Calendar.getGMTInstance();
         calendar.set(year_, month_, day_, hour_, minute_, second_);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
     if (picos_ % 1000 == 0) {
       Timestamp ts = new Timestamp(millis);
       ts.setNanos((int)(picos_ / 1000));
@@ -844,8 +831,7 @@ extends SQLDataBase
         }
 
         calendar.set(0, 0, 0, hour_, minute_, second_);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
         return new Time(millis);
     }
 
@@ -859,8 +845,7 @@ extends SQLDataBase
         }
 
         calendar.set(year_, month_, day_, hour_, minute_, second_);
-        long millis;
-        if (jdk14) { millis =calendar.getTimeInMillis(); } else { millis = calendar.getTime().getTime(); }
+        long millis = calendar.getTimeInMillis();
     if (picos_ % 1000 == 0) {
       Timestamp ts = new Timestamp(millis);
       ts.setNanos((int)(picos_ / 1000));

--- a/src/main/java/com/ibm/as400/access/ServerStartupException.java
+++ b/src/main/java/com/ibm/as400/access/ServerStartupException.java
@@ -152,6 +152,16 @@ public class ServerStartupException extends IOException implements ReturnCodeExc
         rc_ =  returnCode;
     }
 
+    // Constructs a ServerStartupException object.  It indicates that the host server can not be started.  Exception message will look like this: Unable to connect to the port.
+    // @param  returnCode  The return code which identifies the message to be returned.
+    // @param  cause  The cause
+    ServerStartupException(int returnCode, Throwable cause)
+    {
+        // Create the message.
+        super(ResourceBundleLoader.getText(getMRIKey(returnCode)), cause);
+        rc_ =  returnCode;
+    }
+
     // Returns the text associated with the return code.
     // @param  returnCode  The return code associated with this exception.
     // @return  The text string which describes the error.

--- a/src/main/java/com/ibm/as400/access/SystemValueUtility.java
+++ b/src/main/java/com/ibm/as400/access/SystemValueUtility.java
@@ -24,10 +24,6 @@ import java.util.Vector;
 // Contains static methods for setting and getting system values from the system.  Used by the SystemValue, SystemValueGroup, and SystemValueList classes.
 class SystemValueUtility
 {
-  static boolean jdk14 = false;
-  static {
-    jdk14 = JVMInfo.isJDK14();
-  }
 
     // Parses the data stream returned by the Program Call.  Extracts the system value information tables from the data stream.
     // @return  A Vector of Java objects corresponding to the values retrieved from the data stream.
@@ -112,8 +108,7 @@ class SystemValueUtility
                 String stringValue = value.toString();
                 Calendar cal = AS400Calendar.getGregorianInstance();
                 cal.set(1900 + (100 * Integer.parseInt(stringValue.substring(0, 1))) + Integer.parseInt(stringValue.substring(1, 3)), Integer.parseInt(stringValue.substring(3, 5)) - 1, Integer.parseInt(stringValue.substring(5, 7)));
-                long millis;
-                if (jdk14) { millis =cal.getTimeInMillis(); } else { millis = cal.getTime().getTime(); }
+                long millis = cal.getTimeInMillis();
                 value = new java.sql.Date(millis);
             }
             else if (obj.name_.equals("QTIME"))
@@ -125,8 +120,7 @@ class SystemValueUtility
                 cal.set(Calendar.MINUTE, Integer.parseInt(stringValue.substring(2, 4)));
                 cal.set(Calendar.SECOND, Integer.parseInt(stringValue.substring(4, 6)));
                 cal.set(Calendar.MILLISECOND, Integer.parseInt(stringValue.substring(6, 9)));
-                long millis;
-                if (jdk14) { millis =cal.getTimeInMillis(); } else { millis = cal.getTime().getTime(); }
+                long millis = cal.getTimeInMillis();
                 value = new Time(millis);
             }
 

--- a/src/main/java/com/ibm/as400/access/ToolboxLogger.java
+++ b/src/main/java/com/ibm/as400/access/ToolboxLogger.java
@@ -28,18 +28,6 @@ class ToolboxLogger
   private static Logger[] parentLoggers_ = null;
   private final static Object loggerLock_ = new Object();
 
-  private static boolean JDK14_OR_HIGHER;
-  static
-  {
-    try {
-      Class.forName("java.util.logging.LogManager"); // Class added in JDK 1.4.
-      JDK14_OR_HIGHER = true;  // If we got this far, we're on JDK 1.4 or higher.
-    }
-    catch (Throwable e) {      // We're not on JDK 1.4 or higher,
-      JDK14_OR_HIGHER = false; // so don't even try to get the Toolbox Logger.
-    }
-  }
-
   // Private constructor to prevent instantiation by other classes.
   private ToolboxLogger() {}
 
@@ -56,7 +44,7 @@ class ToolboxLogger
    **/
   static final ToolboxLogger getLogger()
   {
-    if (logger_ == null && JDK14_OR_HIGHER)
+    if (logger_ == null)
     {
       synchronized (loggerLock_)
       {

--- a/src/main/java/com/ibm/as400/access/Trace.java
+++ b/src/main/java/com/ibm/as400/access/Trace.java
@@ -311,20 +311,11 @@ public class Trace implements Runnable
   // Design note: We needed to segregate the Logger logic into a separate class.  The Java logging package doesn't exist prior to JDK 1.4, so if we're executing in an older JVM, we get SecurityException's if the JVM sees _any_ runtime reference to a java.util.logging class.
   private static ToolboxLogger logger_ = null;
   private static boolean firstCallToFindLogger_ = true;
-  private static boolean JDK14_OR_HIGHER;
   private static PrintWriter globalPw = null;
 
   // @D0A
   static
   {
-    try {
-      Class.forName("java.util.logging.LogManager"); // Class added in JDK 1.4.
-      JDK14_OR_HIGHER = true;  // If we got this far, we're on JDK 1.4 or higher.
-    }
-    catch (Throwable e) {      // We're not on JDK 1.4 or higher,
-      JDK14_OR_HIGHER = false; // so don't even try to get the Toolbox Logger.
-    }
-
     loadTraceProperties ();
   }
 
@@ -1824,7 +1815,7 @@ private static final void log(int category, Object source, String message, byte[
     if (firstCallToFindLogger_)  // Just do the following checking the first time.
     {
       firstCallToFindLogger_ = false;
-      if ((logger_ == null) && JDK14_OR_HIGHER)
+      if (logger_ == null)
       {
         logger_ = ToolboxLogger.getLogger(); // returns null if no Logger activated
         if (logger_ != null && logger_.isLoggingOn())

--- a/src/main/java/com/ibm/as400/util/BASE64Decoder.java
+++ b/src/main/java/com/ibm/as400/util/BASE64Decoder.java
@@ -94,14 +94,10 @@ public class BASE64Decoder {
            if (cause instanceof Error) {
              throw (Error) cause;
            } else {
-             Error error = new Error("UNEXPECTED EXCEPTION");
-             error.initCause(e);
-             throw error;
+             throw new Error("UNEXPECTED EXCEPTION", e);
            }
          } else {
-           Error error = new Error("UNEXPECTED EXCEPTION");
-           error.initCause(e);
-           throw error;
+           throw new Error("UNEXPECTED EXCEPTION", e);
          }
        }
      } else {

--- a/src/main/java/com/ibm/as400/util/BASE64Encoder.java
+++ b/src/main/java/com/ibm/as400/util/BASE64Encoder.java
@@ -98,14 +98,10 @@ public class BASE64Encoder {
           if (cause instanceof Error) {
             throw (Error) cause;
           } else {
-            Error error = new Error("UNEXPECTED EXCEPTION");
-            error.initCause(e);
-            throw error;
+            throw new Error("UNEXPECTED EXCEPTION", e);
           }
         } else {
-          Error error = new Error("UNEXPECTED EXCEPTION");
-          error.initCause(e);
-          throw error;
+          throw new Error("UNEXPECTED EXCEPTION", e);
         }
       }
     } else {

--- a/src/main/java/com/ibm/as400/vaccess/IFSFileSystemView.java
+++ b/src/main/java/com/ibm/as400/vaccess/IFSFileSystemView.java
@@ -137,21 +137,6 @@ public class IFSFileSystemView extends FileSystemView
       else return file;
     }
 
-
-    // Note: The method createFileSystemRoot() was added to the FileSystemView class in JDK 1.4.
-    // We provide an implementation here to swallow the NoSuchMethodError if running on an older JDK.
-    protected File createFileSystemRoot(File f) {
-      try {
-        return super.createFileSystemRoot(f);
-      }
-      catch (NoSuchMethodError e) {  // method added in JDK 1.4
-        if (Trace.isTraceOn()) {
-          Trace.log(Trace.DIAGNOSTIC, e);
-        }
-        return f;
-      }
-    }
-
     /**
      Creates a new folder with a default name.
      <br>Note: In the context of this class, "folder" is synonymous with "directory".


### PR DESCRIPTION
Almost all the removed parts of code are workarounds for things missing from JDK < 1.4:

- `java.util.logging`
- [`Calendar.getTimeInMillis()`](https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/util/Calendar.html#getTimeInMillis()) 
- [`Throwable.initCause(Throwable cause)`](https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/lang/Throwable.html#initCause(java.lang.Throwable))

Where possible, exceptions creation has been simplified, for example using `IOException` and `SQLException` constructors with the `cause` parameter (added in Java 6).

There are other jdk workarounds in the code (eg. BigDecimal), but I'll work on them in another PRs not to make this one too big.