### PR TITLE
fix: trace exception when deleting physical files

### DIFF
--- a/src/main/java/com/ibm/as400/access/IFSFile.java
+++ b/src/main/java/com/ibm/as400/access/IFSFile.java
@@ -1776,7 +1776,22 @@ public class IFSFile
     }
     return subType_;
   }
+  private boolean isInFileSystem(String _fs) {
+    String lowercasePath = path_.toLowerCase().replaceAll("//+","/");
+    return lowercasePath.equals("/"+_fs.toLowerCase()) || lowercasePath.startsWith("/"+_fs.toLowerCase()+"/");
 
+  }
+
+  public boolean isInQOpenSys() {
+    return isInFileSystem("QOpenSys");
+  }
+
+  public boolean isInQsys() {
+    return isInFileSystem("qsys.lib");
+  }
+  public boolean isInQDLS() {
+    return isInFileSystem("qdls");
+  }
 
   /**
    Determines if the file is an IBM i "source physical file".

--- a/src/main/java/com/ibm/as400/access/IFSFileImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/IFSFileImplRemote.java
@@ -1771,6 +1771,11 @@ implements IFSFileImpl
 
     return result;
   }
+  
+  private boolean isInQsys() {
+    String lowercasePath = fd_.path_.toLowerCase().replaceAll("//+","/");
+    return lowercasePath.equals("/qsys.lib") || lowercasePath.startsWith("/qsys.lib/");
+  }
 
   /**
    Determines if the integrated file system object represented by this
@@ -1827,6 +1832,12 @@ implements IFSFileImpl
     //
     if (!determinedIsSymbolicLink_)
     {
+      // QSYS doesn't support symbolic links, so no need to check
+      if(isInQsys()) {
+        isSymbolicLink_ = false;
+        determinedIsSymbolicLink_ = true;
+        return isSymbolicLink_;
+      }
       // Note: As of V5R3, we can't get accurate symbolic link info by querying the attrs of a specific file.
       // Instead, we must query the contents of the parent directory.
       int pathLen = fd_.path_.length();


### PR DESCRIPTION
When deleting physical files (in particular those created with `CRTPF`, an unexpected failure may occur. Exception data in traces may resemble the following:

```pascal
Received zero matches from listDirectoryDetails() against parent of /qsys.lib/abc.lib/MYFILE.FIL*
java.lang.Throwable
    at com.ibm.as400.access.Trace.logData(Trace.java:767)
    at com.ibm.as400.access.Trace.log(Trace.java:827)
    at com.ibm.as400.access.IFSFileImplRemote.isSymbolicLink(IFSFileImplRemote.java:1865)
    at com.ibm.as400.access.IFSFileImplRemote.delete(IFSFileImplRemote.java:516)
    at com.ibm.as400.access.IFSFile.delete0(IFSFile.java:851)
    at com.ibm.as400.access.IFSFile.delete(IFSFile.java:898)
```