### PR TITLE
Add getMessageOption() and setMessageOption() to ProgramCallDocument

### DIFF
--- a/src/main/java/com/ibm/as400/data/PcmlDocument.java
+++ b/src/main/java/com/ibm/as400/data/PcmlDocument.java
@@ -591,6 +591,15 @@ class PcmlDocument extends PcmlDocRoot
     }
 
     /**
+    Returns the option for how many messages will be retrieved for the specified program.
+    @return  A constant indicating how many messages will be retrieved.
+    **/
+    synchronized int getMessageOption(String name) throws PcmlException
+    {
+        return getProgramNode(name).getMessageOption();
+    }
+
+    /**
      Returns the ProgramCall object that was used in the most recent invocation of {@link #callProgram() callProgram()}.
      @return The ProgramCall object; null if callProgram has not been called.
      **/
@@ -691,6 +700,18 @@ class PcmlDocument extends PcmlDocRoot
     {                                                               // @C6A
         return getProgramNode(program).getThreadsafeOverride();     // @C6A
     }                                                               // @C6A
+
+    /**
+    Specifies the option for how many messages should be retrieved for the specified program.  By default, to preserve
+    compatability, only the messages sent to the program caller and only up to ten messages are retrieved.
+    This property will only take effect on systems that support the new option.
+    @param  messageOption  A constant indicating how many messages to retrieve.
+    **/
+    synchronized void setMessageOption(String program, int messageOption)
+        throws PcmlException
+    {
+        getProgramNode(program).setMessageOption(messageOption);
+    }
 
     // Add a subtree to the document's hashtable.
     // This is called to complete the document cloneing process.

--- a/src/main/java/com/ibm/as400/data/ProgramCallDocument.java
+++ b/src/main/java/com/ibm/as400/data/ProgramCallDocument.java
@@ -791,6 +791,25 @@ public class ProgramCallDocument implements Serializable, Cloneable
     }
 
     /**
+    Returns the option for how many messages will be retrieved for the specified program.
+
+    @param name The name of the &lt;program&gt; element in the PCML document.
+    @return  A constant indicating how many messages will be retrieved.  Valid values are:
+    <ul>
+    <li>{@link AS400Message#MESSAGE_OPTION_UP_TO_10 MESSAGE_OPTION_UP_TO_10}
+    <li>{@link AS400Message#MESSAGE_OPTION_NONE MESSAGE_OPTION_NONE}
+    <li>{@link AS400Message#MESSAGE_OPTION_ALL MESSAGE_OPTION_ALL}
+    </ul>
+    @exception PcmlException
+               If an error occurs.
+    **/
+    public int getMessageOption(String name)
+        throws PcmlException
+    {
+        return m_pcmlDoc.getMessageOption(name);
+    }
+
+    /**
     Returns the number of bytes reserved for output for the named element.
 
     @return The number of bytes reserved for output for the named element.
@@ -1349,6 +1368,27 @@ public class ProgramCallDocument implements Serializable, Cloneable
         throws PcmlException
     {
         return m_pcmlDoc.getThreadsafeOverride(program);           // @C6A
+    }
+
+    /**
+    Specifies the option for how many messages should be retrieved for the specified program.  By default, to preserve
+    compatability, only the messages sent to the program caller and only up to ten messages are retrieved.
+    This property will only take effect on systems that support the new option.
+
+    @param  program  The name of the &lt;program&gt; element in the PCML document.
+    @param  messageOption  A constant indicating how many messages to retrieve.  Valid values are:
+    <ul>
+    <li>AS400Message.MESSAGE_OPTION_UP_TO_10
+    <li>AS400Message.MESSAGE_OPTION_NONE
+    <li>AS400Message.MESSAGE_OPTION_ALL
+    </ul>
+    @exception PcmlException
+               If an error occurs.
+    **/
+    public void setMessageOption(String program, int messageOption)
+        throws PcmlException
+    {
+        m_pcmlDoc.setMessageOption(program, messageOption);
     }
 
 
@@ -2013,5 +2053,4 @@ public class ProgramCallDocument implements Serializable, Cloneable
         return m_timeOut;
     }
     //@Y6A End
-
 }


### PR DESCRIPTION
This PR implements two new functions on `ProgramCallDocument`: `getMessageOption()` and `setMessageOption()`. These new functions allow users to specify how many messages should be returned when calling a given program in their (X)PCML document. This option already existed on standard ProgramCalls and ServiceProgramCalls, but this option was not exposed to users of ProgramCallDocuments, thus locking them to the default of `AS400Message.MESSAGE_OPTION_UP_TO_10`. This PR now exposes that option to ProgramCallDocument users. They behave exactly the same as the functions of the same names in the `ProgramCall` class (since all these changes do is just call those `ProgramCall` functions to propagate the value when `ProgramCallDocument.callProgram()` is called).

This PR also makes a change to when the message list is saved when calling a program through a `ProgramCallDocument`. Previously, the message list would only be saved if the program call signaled that the call errored. So a successful call would not save off the messages, even if the program call _did_ return messages during the call. In the standard `ProgramCall`, the message list was always saved off after the call was made, no matter the result of the call. So I have changed `ProgramCallDocument` to do the same. Now, `ProgramCallDocument.getMessageList()` will always have whatever messages were returned from the most recent call for the given program node, based on the message option value.