### PR TITLE
Replace all usages of QGY.LIB APIs with their QSYS.LIB equivalents.

### DIFF
--- a/pcml/RJobList.pcml
+++ b/pcml/RJobList.pcml
@@ -29,7 +29,7 @@
 
 
 
-<program name="qgyoljob" path="/QSYS.LIB/QGY.LIB/QGYOLJOB.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyoljob" path="/QSYS.LIB/QGYOLJOB.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljb0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="lengthOfReceiverVariable"/>
@@ -93,7 +93,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljb0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -107,7 +107,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/pcml/RJobLog.pcml
+++ b/pcml/RJobLog.pcml
@@ -30,7 +30,7 @@
 
 
 
-<program name="qgyoljbl" path="/QSYS.LIB/QGY.LIB/QGYOLJBL.PGM" parseorder="listInformation receiverVariable" threadsafe="false">        
+<program name="qgyoljbl" path="/QSYS.LIB/QGYOLJBL.PGM" parseorder="listInformation receiverVariable" threadsafe="false">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljl0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength"/>
@@ -66,7 +66,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljl0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -80,7 +80,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/pcml/RMessageQueue.pcml
+++ b/pcml/RMessageQueue.pcml
@@ -22,7 +22,7 @@
 
 
 
-<program name="qgyolmsg" path="/QSYS.LIB/QGY.LIB/QGYOLMSG.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyolmsg" path="/QSYS.LIB/QGYOLMSG.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="lstm0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="lengthOfReceiverVariable"/>
@@ -68,7 +68,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="lstm0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -82,7 +82,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/pcml/RPrinter.pcml
+++ b/pcml/RPrinter.pcml
@@ -15,7 +15,7 @@
 
 
 
-<program name="qgyrprta_rpta0100" path="/QSYS.LIB/QGY.LIB/QGYRPRTA.PGM">
+<program name="qgyrprta_rpta0100" path="/QSYS.LIB/QGYRPRTA.PGM">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="rpta0100"
                                                                                 outputsize="receiverVariableLength"/>
         <data name="receiverVariableLength"             usage="input"           type="int" length="4" init="370"/>

--- a/pcml/RPrinterList.pcml
+++ b/pcml/RPrinterList.pcml
@@ -15,7 +15,7 @@
 
 
 
-<program name="qgyrprtl" path="/QSYS.LIB/QGY.LIB/QGYRPRTL.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyrprtl" path="/QSYS.LIB/QGYRPRTL.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="prtl0200"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength"/>
@@ -62,7 +62,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="prtl0200"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -76,7 +76,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/pcml/RUserList.pcml
+++ b/pcml/RUserList.pcml
@@ -15,7 +15,7 @@
 
 
 
-<program name="qgyolaus" path="/QSYS.LIB/QGY.LIB/QGYOLAUS.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyolaus" path="/QSYS.LIB/QGYOLAUS.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="autu0150"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength"/>
@@ -41,7 +41,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="autu0150"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -55,7 +55,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/src/main/java/com/ibm/as400/access/ISeriesPrinter.java
+++ b/src/main/java/com/ibm/as400/access/ISeriesPrinter.java
@@ -1563,7 +1563,7 @@ public class ISeriesPrinter implements Serializable
         };
 
         // Note this is not an open list API, even though it starts with QGY.
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYRPRTA.PGM", parameters);
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYRPRTA.PGM", parameters);
         if (!pc.run())
         {
             throw new AS400Exception(pc.getMessageList());

--- a/src/main/java/com/ibm/as400/access/JobList.java
+++ b/src/main/java/com/ibm/as400/access/JobList.java
@@ -1562,7 +1562,7 @@ public class JobList implements Serializable
         };
 
         // Call the program.
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYOLJOB.PGM", parameters);
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYOLJOB.PGM", parameters);
 
         if (!pc.run())
         {

--- a/src/main/java/com/ibm/as400/access/JobLog.java
+++ b/src/main/java/com/ibm/as400/access/JobLog.java
@@ -691,7 +691,7 @@ public class JobLog implements Serializable
         };
 
         // Call the program. This API is not thread safe. 
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYOLJBL.PGM", parameters);  // not a threadsafe API
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYOLJBL.PGM", parameters);  // not a threadsafe API
         if (!pc.run())
         {
             throw new AS400Exception(pc.getMessageList());

--- a/src/main/java/com/ibm/as400/access/ListUtilities.java
+++ b/src/main/java/com/ibm/as400/access/ListUtilities.java
@@ -161,7 +161,7 @@ class ListUtilities
       new ProgramParameter(listHandle),
       new ErrorCodeParameter()
     };
-    ProgramCall pc = new ProgramCall(system, "/QSYS.LIB/QGY.LIB/QGYCLST.PGM", parameters);  // not a threadsafe API
+    ProgramCall pc = new ProgramCall(system, "/QSYS.LIB/QGYCLST.PGM", parameters);  // not a threadsafe API
     if (!pc.run())
     {
       throw new AS400Exception(pc.getMessageList());
@@ -197,7 +197,7 @@ class ListUtilities
         new ErrorCodeParameter()
 
       };          
-      try { pgmCall.setProgram("/QSYS.LIB/QGY.LIB/QGYGTLE.PGM", parameters); }
+      try { pgmCall.setProgram("/QSYS.LIB/QGYGTLE.PGM", parameters); }
       catch (java.beans.PropertyVetoException pve) {} // will never happen
     }
 
@@ -290,7 +290,7 @@ class ListUtilities
       new ErrorCodeParameter()
     };
 
-    ProgramCall pc = new ProgramCall(system, "/QSYS.LIB/QGY.LIB/QGYGTLE.PGM", parameters); // not a threadsafe API
+    ProgramCall pc = new ProgramCall(system, "/QSYS.LIB/QGYGTLE.PGM", parameters); // not a threadsafe API
 
     byte[] listInformation;
     int recordsReturned;

--- a/src/main/java/com/ibm/as400/access/MessageQueue.java
+++ b/src/main/java/com/ibm/as400/access/MessageQueue.java
@@ -862,7 +862,7 @@ public class MessageQueue implements Serializable
         };
 
         // Call the program.
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYOLMSG.PGM", parameters); // not a threadsafe API
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYOLMSG.PGM", parameters); // not a threadsafe API
         if (!pc.run())
         {
             throw new AS400Exception(pc.getMessageList());

--- a/src/main/java/com/ibm/as400/access/ObjectList.java
+++ b/src/main/java/com/ibm/as400/access/ObjectList.java
@@ -1393,7 +1393,7 @@ public class ObjectList implements Serializable
     }
 
     // Call the program
-    ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYOLOBJ.PGM", parms);
+    ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYOLOBJ.PGM", parms);
     if (!pc.run())
     {
       throw new AS400Exception(pc.getMessageList());

--- a/src/main/java/com/ibm/as400/access/UserList.java
+++ b/src/main/java/com/ibm/as400/access/UserList.java
@@ -513,7 +513,7 @@ public class UserList implements Serializable
         };
 
         // Call the program.
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYOLAUS.PGM", parameters);
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYOLAUS.PGM", parameters);
         if (!pc.run())
         {
             throw new AS400Exception(pc.getMessageList());

--- a/src/main/java/com/ibm/as400/access/ValidationList.java
+++ b/src/main/java/com/ibm/as400/access/ValidationList.java
@@ -155,7 +155,7 @@ private void closeList(byte[] handle) throws PersistenceException {
 	ProgramCall pgm = new ProgramCall(getAS400());
 	ProgramParameter[] parmList = new ProgramParameter[2];
 	try {
-		pgm.setProgram(QSYSObjectPathName.toPath("QGY", "QGYCLST", "PGM"), parmList);
+		pgm.setProgram(QSYSObjectPathName.toPath("QSYS", "QGYCLST", "PGM"), parmList);
 	} catch (PropertyVetoException pve) { Trace.log(Trace.ERROR, pve); }
 
 	// Refer to documentation for the QGYCLST generic list API for a complete description of parameters
@@ -322,7 +322,7 @@ public ValidationListEntry[] getEntries() throws PersistenceException {
 	ProgramParameter[] parmList = new ProgramParameter[7];
 	int bufferLength = LISTBUFFER_LENGTH_INITIAL;
 	try {
-		pgm.setProgram(QSYSObjectPathName.toPath("QGY", "QSYOLVLE", "PGM"), parmList);
+		pgm.setProgram(QSYSObjectPathName.toPath("QSYS", "QSYOLVLE", "PGM"), parmList);
 	} catch (PropertyVetoException pve) { Trace.log(Trace.ERROR, pve); }
 	
 	// Refer to documentation for the QSYOLVLE Security API for a complete description of parameters
@@ -420,7 +420,7 @@ private int getNextEntries(byte[] listHandle, int listPosition, ValidationListEn
 		// Try & retrieve all remaining entries in a single call; keeps it simple for now
 		int bufferLength = LISTBUFFER_LENGTH_NEXT;
 		try {
-			pgm.setProgram(QSYSObjectPathName.toPath("QGY", "QGYGTLE", "PGM"), parmList);
+			pgm.setProgram(QSYSObjectPathName.toPath("QSYS", "QGYGTLE", "PGM"), parmList);
 		} catch (PropertyVetoException pve) { Trace.log(Trace.ERROR, pve); }
 
 		// Refer to documentation for the QGYGTLE generic list API for a complete description of parameters
@@ -451,7 +451,7 @@ public int getNumberOfEntries() throws PersistenceException {
 	ProgramParameter[] parmList = new ProgramParameter[7];
 	int bufferLength = 512;
 	try {
-		pgm.setProgram(QSYSObjectPathName.toPath("QGY", "QSYOLVLE", "PGM"), parmList);
+		pgm.setProgram(QSYSObjectPathName.toPath("QSYS", "QSYOLVLE", "PGM"), parmList);
 	} catch (PropertyVetoException pve) { Trace.log(Trace.ERROR, pve); }
 	
 	// Refer to documentation for the QSYOLVLE Security API for a complete description of parameters

--- a/src/main/java/com/ibm/as400/access/list/AspOpenList.java
+++ b/src/main/java/com/ibm/as400/access/list/AspOpenList.java
@@ -270,7 +270,7 @@ public class AspOpenList extends OpenList {
      //parameters[8] = new ProgramParameter(sortInformation)
      
      // Call the program.
-     ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QYASPOL.PGM", parameters);
+     ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QYASPOL.PGM", parameters);
      if (!pc.run())
      {
          throw new AS400Exception(pc.getMessageList());

--- a/src/main/java/com/ibm/as400/access/list/OpenList.java
+++ b/src/main/java/com/ibm/as400/access/list/OpenList.java
@@ -163,7 +163,7 @@ public abstract class OpenList implements Serializable
                 new ProgramParameter(handle_),
                 EMPTY_ERROR_CODE_PARM
             };
-            ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYCLST.PGM", parameters);
+            ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYCLST.PGM", parameters);
             if (!pc.run())
             {
                 throw new AS400Exception(pc.getMessageList());
@@ -373,7 +373,7 @@ public abstract class OpenList implements Serializable
             EMPTY_ERROR_CODE_PARM
         };
 
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYGTLE.PGM", parameters);
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYGTLE.PGM", parameters);
 
         byte[] listInformation = null;
         int recordsReturned = 0;

--- a/src/main/java/com/ibm/as400/access/list/SpooledFileOpenList.java
+++ b/src/main/java/com/ibm/as400/access/list/SpooledFileOpenList.java
@@ -706,7 +706,7 @@ public class SpooledFileOpenList extends OpenList
         }
 
         // Call the program.
-        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGY.LIB/QGYOLSPL.PGM", parameters);
+        ProgramCall pc = new ProgramCall(system_, "/QSYS.LIB/QGYOLSPL.PGM", parameters);
         if (!pc.run())
         {
             throw new AS400Exception(pc.getMessageList());

--- a/src/main/resources/com/ibm/as400/resource/RJobList.pcml
+++ b/src/main/resources/com/ibm/as400/resource/RJobList.pcml
@@ -29,7 +29,7 @@
 
 
 
-<program name="qgyoljob" path="/QSYS.LIB/QGY.LIB/QGYOLJOB.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyoljob" path="/QSYS.LIB/QGYOLJOB.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljb0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="lengthOfReceiverVariable"/>
@@ -93,7 +93,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljb0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -107,7 +107,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/src/main/resources/com/ibm/as400/resource/RJobLog.pcml
+++ b/src/main/resources/com/ibm/as400/resource/RJobLog.pcml
@@ -30,7 +30,7 @@
 
 
 
-<program name="qgyoljbl" path="/QSYS.LIB/QGY.LIB/QGYOLJBL.PGM" parseorder="listInformation receiverVariable" threadsafe="false">        
+<program name="qgyoljbl" path="/QSYS.LIB/QGYOLJBL.PGM" parseorder="listInformation receiverVariable" threadsafe="false">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljl0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength"/>
@@ -66,7 +66,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="oljl0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -80,7 +80,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/src/main/resources/com/ibm/as400/resource/RMessageQueue.pcml
+++ b/src/main/resources/com/ibm/as400/resource/RMessageQueue.pcml
@@ -22,7 +22,7 @@
 
 
 
-<program name="qgyolmsg" path="/QSYS.LIB/QGY.LIB/QGYOLMSG.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyolmsg" path="/QSYS.LIB/QGYOLMSG.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="lstm0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="lengthOfReceiverVariable"/>
@@ -68,7 +68,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="lstm0100"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -82,7 +82,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/src/main/resources/com/ibm/as400/resource/RPrinter.pcml
+++ b/src/main/resources/com/ibm/as400/resource/RPrinter.pcml
@@ -15,7 +15,7 @@
 
 
 
-<program name="qgyrprta_rpta0100" path="/QSYS.LIB/QGY.LIB/QGYRPRTA.PGM">
+<program name="qgyrprta_rpta0100" path="/QSYS.LIB/QGYRPRTA.PGM">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="rpta0100"
                                                                                 outputsize="receiverVariableLength"/>
         <data name="receiverVariableLength"             usage="input"           type="int" length="4" init="370"/>

--- a/src/main/resources/com/ibm/as400/resource/RPrinterList.pcml
+++ b/src/main/resources/com/ibm/as400/resource/RPrinterList.pcml
@@ -15,7 +15,7 @@
 
 
 
-<program name="qgyrprtl" path="/QSYS.LIB/QGY.LIB/QGYRPRTL.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyrprtl" path="/QSYS.LIB/QGYRPRTL.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="prtl0200"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength"/>
@@ -62,7 +62,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="prtl0200"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -76,7 +76,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>

--- a/src/main/resources/com/ibm/as400/resource/RUserList.pcml
+++ b/src/main/resources/com/ibm/as400/resource/RUserList.pcml
@@ -15,7 +15,7 @@
 
 
 
-<program name="qgyolaus" path="/QSYS.LIB/QGY.LIB/QGYOLAUS.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgyolaus" path="/QSYS.LIB/QGYOLAUS.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="autu0150"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength"/>
@@ -41,7 +41,7 @@
 
 
 
-<program name="qgygtle" path="/QSYS.LIB/QGY.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">        
+<program name="qgygtle" path="/QSYS.LIB/QGYGTLE.PGM" parseorder="listInformation receiverVariable">
         <data name="receiverVariable"                   usage="output"          type="struct" struct="autu0150"
                                                                                 count="listInformation.recordsReturned"
                                                                                 outputsize="receiverVariableLength" />
@@ -55,7 +55,7 @@
 
 
 
-<program name="qgyclst" path="/QSYS.LIB/QGY.LIB/QGYCLST.PGM">
+<program name="qgyclst" path="/QSYS.LIB/QGYCLST.PGM">
         <data name="requestHandle"                      usage="input"           type="byte" length="4"/>
         <data name="errorCode"                          usage="input"           type="int" length="4" init="0"/>                    
 </program>


### PR DESCRIPTION
In V5R3, the "Open List APIs" were moved from SS1 Option 12 (in library QGY) to SS1 *BASE (in library QSYS). Stub programs were left in QGY to just route any calls to them over to the new QSYS programs, so this has technically continued to work just fine. However, the wording in the [V5R3 Memo to Users][1] stated that (on page 52):

> These router programs and the library QGY will be removed in a future release. You should change any applications that make library-qualified calls to the Open List APIs in library QGY to call the APIs in library QSYS.

As support for connecting to V5R2 was dropped with JTOpen 6.1 (2007), it seems like we can safely do this now.

The motivation behind making this PR now was due to some internal usage of Java Toolbox, during an install of the operating system. Our internal tooling failed to complete the install because Option 12 was not installed, so the QGY library was missing. However, the base OS had installed fine, so the programs it was trying to access were _technically_ there. It's just that the stub/router programs were missing. Since it seems odd to continue to use these router programs when we should really be using the main programs, I decided to make this PR. This has the added benefit of removing another dependency on Option 12, and instead shifting that requirement over to the base OS.

It should be noted that I was not able to run the JTOpen-test suite because its setup confused me 🙂, but I spot tested some of these changes and they worked fine. Perhaps someone with more knowledge should run the relevant tests and make sure everything still works as expected (I'm fairly certain that they should, but those are famous last words).

[1]: https://public.dhe.ibm.com/systems/power/docs/systemi/v5r3/en_US/rzaq9.pdf