### PR TITLE
Fix race condition initializing attributes data structure

### DIFF
--- a/src/main/java/com/ibm/as400/access/AFPResourceImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/AFPResourceImplRemote.java
@@ -32,7 +32,6 @@ class AFPResourceImplRemote extends PrintObjectImplRemote
     {
         if (!fAttrIDsToRtvBuilt_)
         {
-            fAttrIDsToRtvBuilt_ = true;
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_DATE);       // date
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_DESCRIPTION);// text description
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_OBJEXTATTR); // object extended attribute
@@ -41,6 +40,7 @@ class AFPResourceImplRemote extends PrintObjectImplRemote
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_RSCTYPE);    // resource object type
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_TIME);       // time
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_NUMBYTES);   // number of bytes to read/write
+            fAttrIDsToRtvBuilt_ = true;
         }
     }
 

--- a/src/main/java/com/ibm/as400/access/OutputQueueImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/OutputQueueImplRemote.java
@@ -35,7 +35,6 @@ implements OutputQueueImpl
     {
 	    if (!fAttrIDsToRtvBuilt_)
 	    {
-	        fAttrIDsToRtvBuilt_ = true;
 	        // 27 of these
 	        attrsToRetrieve_.addAttrID(PrintObject.ATTR_AUTHCHCK);      // Authority to check
 	        attrsToRetrieve_.addAttrID(PrintObject.ATTR_DATAQUELIB);    // Data queue library name
@@ -65,6 +64,7 @@ implements OutputQueueImpl
 	        attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBNUM);     // Writer job number
 	        attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBSTS);     // Writer job status
 	        attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBUSER);    // Writer job user name
+	        fAttrIDsToRtvBuilt_ = true;
 	    }
     }
 

--- a/src/main/java/com/ibm/as400/access/SpooledFileImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/SpooledFileImplRemote.java
@@ -138,7 +138,6 @@ implements SpooledFileImpl
     {
         if (!fAttrIDsToRtvBuilt_)
         {
-            fAttrIDsToRtvBuilt_ = true;
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_3812SCS);       // 3812 SCS (fonts)
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_ACCOUNT_CODE);  // Accounting code
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_AFP);           // AFP resources used
@@ -326,6 +325,7 @@ implements SpooledFileImpl
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_USRDEFOBJLIB);  // *User defined object library
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_USRDEFOBJTYP);  // *User defined object type
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_USRDEFOPT);     // User defined options
+            fAttrIDsToRtvBuilt_ = true;
         }
     }
 

--- a/src/main/java/com/ibm/as400/access/WriterJobImplRemote.java
+++ b/src/main/java/com/ibm/as400/access/WriterJobImplRemote.java
@@ -38,11 +38,11 @@ implements WriterJobImpl
     {
         if (!fAttrIDsToRtvBuilt_)
         {
-            fAttrIDsToRtvBuilt_ = true;
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBNAME);       // writer job name
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBNUM);        // writer job number
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBSTS);        // writer job status
             attrsToRetrieve_.addAttrID(PrintObject.ATTR_WTRJOBUSER);       // writer job user name
+            fAttrIDsToRtvBuilt_ = true;
         }
     }
 


### PR DESCRIPTION
I occasionally get an error when calling `SpooledFile.getIntegerAttribute(PrintObject.ATTR_PAGES)`:
```
com.ibm.as400.access.ExtendedIllegalArgumentException: ATTR_PAGES: Parameter value is not valid.
	at com.ibm.as400.access.PrintObjectImplRemote.getIntegerAttribute(PrintObjectImplRemote.java:133)
	at com.ibm.as400.access.PrintObject.getIntegerAttribute(PrintObject.java:844)
```

The code in question is multithreaded, but the `AS400` are not shared across threads.

### Reproduction

Fill in the connection info and use the attributes of any spooled file on the system.

```java
import com.ibm.as400.access.AS400;
import com.ibm.as400.access.PrintObject;
import com.ibm.as400.access.SpooledFile;

import java.util.Collections;
import java.util.concurrent.Callable;
import java.util.concurrent.CountDownLatch;
import java.util.concurrent.Executors;

public class Reproduction {
    public static void main(String[] args) throws Exception {
        // connection info
        var system = "";
        var userId = "";
        var password = "";

        // spooled file info
        var name = "";
        var number = 0;
        var jobName = "";
        var jobUser = "";
        var jobNumber = "";

        var executor = Executors.newCachedThreadPool();
        try {
            var threadCount = 5;
            var latch = new CountDownLatch(threadCount);

            Callable<String> task = () -> {
                // one AS400 instance per thread
                try (var as400 = new AS400(system, userId, password)) {
                    as400.connectService(AS400.PRINT);
                    var spooledFile = new SpooledFile(as400, name, number, jobName, jobUser, jobNumber);

                    // wait for all threads to maximize the chance of race condition
                    latch.countDown();

                    // use the last attribute value to maximize the chance of race condition
                    return spooledFile.getStringAttribute(PrintObject.ATTR_USRDEFOPT);
                }
            };
            var results = executor.invokeAll(Collections.nCopies(threadCount, task));
            for (var result : results) {
                System.out.println("ATTR_USRDEFOPT = " + result.get());
            }
        } finally {
            executor.shutdown();
        }
    }
}
```

### Solution

The spooled file attributes data structure is shared across threads:
https://github.com/IBM/JTOpen/blob/5702fe2878e89b0f4b9940763e2282d16753f045/src/main/java/com/ibm/as400/access/SpooledFileImplRemote.java#L36-L37

The first `SpooledFile` to access the attributes will initialize the data structure:
https://github.com/IBM/JTOpen/blob/5702fe2878e89b0f4b9940763e2282d16753f045/src/main/java/com/ibm/as400/access/SpooledFileImplRemote.java#L461-L467

The problem is that `fAttrIDsToRtvBuilt_` is set `true` _before_ being fully initialized, so the next thread can see a partially initialized attributes:
https://github.com/IBM/JTOpen/blob/5702fe2878e89b0f4b9940763e2282d16753f045/src/main/java/com/ibm/as400/access/SpooledFileImplRemote.java#L137-L144

The solution in this PR is to set `fAttrIDsToRtvBuilt_ = true` after the attributes are fully initialized.

The same pattern is used in some other places besides `SpooledFile`, so I fixed those too.
