### PR TITLE
Fix bug where setting validateSignonTimeOut causes the soTimeout to also be set after calling AS400.validateSignon()

### DIFF
--- a/src/main/java/com/ibm/as400/access/AS400.java
+++ b/src/main/java/com/ibm/as400/access/AS400.java
@@ -1064,8 +1064,7 @@ public class AS400 implements Serializable, AutoCloseable
         threadUsed_ = system.threadUsed_;
         locale_ = system.locale_;
         nlv_ = system.nlv_;
-        socketProperties_ = system.socketProperties_;
-
+        socketProperties_.copyValues(system.socketProperties_);
         ccsid_ = system.ccsid_;
 
         // connectionListeners_ is not copied.

--- a/src/main/java/com/ibm/as400/access/AS400.java
+++ b/src/main/java/com/ibm/as400/access/AS400.java
@@ -5673,7 +5673,7 @@ public class AS400 implements Serializable, AutoCloseable
                 // threadUsed_ is not needed.
                 // locale_ in not needed.
                 // nlv_ in not needed.
-                validationSystem.socketProperties_ = socketProperties_;
+                validationSystem.socketProperties_.copyValues(socketProperties_);
                 if (validateSignonTimeOut_ > 0)
                     validationSystem.socketProperties_.setSoTimeout(validateSignonTimeOut_);
                 // ccsid_ is not needed.


### PR DESCRIPTION
An issue was discovered internally where calling `AS400.setvalidateSignonTimeOut()` and then subsequently calling `AS400.validateSignon()` would cause the SocketProperties on that AS400 object to have the `soTimeout` set for future host server connections. This causes an issue when threads are used for communication, as soTimeout and threadsUsed are generally incompatible. This manifested as "Read time out" errors in code that had a long time between requests to the system. Switching the `validateSignon()` code to copy the socket properties instead of changing the main reference cleared up the issue.