### PR TITLE
pass custom factory in copy constructor

### DIFF
--- a/src/main/java/com/ibm/as400/access/SSLOptions.java
+++ b/src/main/java/com/ibm/as400/access/SSLOptions.java
@@ -35,6 +35,7 @@ class SSLOptions implements Serializable
         keyRingData_ = sslOptions.keyRingData_;
         proxyEncryptionMode_ = sslOptions.proxyEncryptionMode_;
         useSslight_ = sslOptions.useSslight_;
+        sslSocketFactory_ = sslOptions.sslSocketFactory_;
     }
     
 


### PR DESCRIPTION
This is the patch I referenced here: https://github.com/IBM/JTOpen/pull/200#issuecomment-2611013412

Our code uses connections/pooling based on AS400 objects and not properties.  Ultimately it goes through AS400JDBCDataSource.getConnection, which uses a copy of the AS400 object for the connection.  The AS400 copy constructor in turn uses the SSLOptions copy constructor.  This just adds the new property to the copy constructor with the others, which then carries through and custom SSL properties work for SQL connections.