### PR TITLE
Add custom URL path and query parameters to ProxyClient

### DIFF
--- a/src/main/java/com/ibm/as400/access/PSTunnelController.java
+++ b/src/main/java/com/ibm/as400/access/PSTunnelController.java
@@ -29,7 +29,7 @@ import java.util.Enumeration;
 The PSTunnelController class represents a connection
 to a client of the proxy server.
 **/
-class PSTunnelController
+public class PSTunnelController
 {
   private static final String copyright = "Copyright (C) 1997-2000 International Business Machines Corporation and others.";
 

--- a/src/main/java/com/ibm/as400/access/PxClientConnectionAdapter.java
+++ b/src/main/java/com/ibm/as400/access/PxClientConnectionAdapter.java
@@ -147,8 +147,8 @@ Closes the connection to the proxy server.
 
         // Parse the proxy server name, port number (and protocol if tunneling)
         localName    = proxyServer;
-        String protocolName = null;
-
+        URI uri = null;
+        
         int port = -1;
 
         // determine if we are going with traditional or tunnel proxy.
@@ -157,9 +157,10 @@ Closes the connection to the proxy server.
         if (proxyServer.indexOf("://") > 0)                                    // @D1a
         {
            tunnel_ = true;
-           // the name of the server is everything beyond the ://
-           localName    = proxyServer.substring(proxyServer.indexOf(":") + 3);
-           protocolName = proxyServer.substring(0, proxyServer.indexOf(":"));
+           // greenscreens
+           uri = URI.create(proxyServer);
+           localName = uri.getHost();
+           port = uri.getPort();
         }
 
         // now strip the port of the end of the server name (if one exists)
@@ -181,7 +182,7 @@ Closes the connection to the proxy server.
         else
         {
            // when openTunnel comes back move creating tunnelURL_ to the try/catch.
-           openTunnel(protocolName, localName, port);                                                         // @D1a
+        	openTunnel(uri);                                                        // @D1a
         }
     }
 
@@ -251,17 +252,19 @@ Closes the connection to the proxy server.
 
 
     // @D1a New method
-    void openTunnel(String protocol, String name, int port)
+    void openTunnel(URI uri)
     {
        try
        {
           readDaemon_ = new PxClientReadDaemon();
           readDaemon_.register(new PxAcceptRepCV());
 
-          if (port < 0)
-             tunnelURL_ = new URL(protocol, name, "/servlet/com.ibm.as400.access.TunnelProxyServer");
-          else
-             tunnelURL_ = new URL(protocol, name, port, "/servlet/com.ibm.as400.access.TunnelProxyServer");
+          // greenscreens
+			if (uri.getPath() == null) {
+				tunnelURL_ = uri.resolve("/servlet/com.ibm.as400.access.TunnelProxyServer").toURL();
+			} else {
+				tunnelURL_ = uri.toURL();
+			}
        }
        catch (IOException e)
        {


### PR DESCRIPTION

JT400 contains standalone class ProxyServer to create a simple http server.

```Java
ProxyServer proxyServer = new ProxyServer ();
proxyServer.setMaxConnections (25);
proxyServer.run ();
```

The problem is when there is a need to create embedded proxied JT400 servlet inside web servers such as Tomcat, Wildfly etc. 
because PxClientConnectionAdapter contains fixed URL destination (/servlet/com.ibm.as400.access.TunnelProxyServer) always attached to the AS400 provided host address. 

```Java
String proxy = "https://mywebserver:8443"
AS400 system = new AS400("ibm_server", "demo", "demo", proxy);
```

Resulting URL inside AS400 proxied connection will be https://mywebserver:8443/servlet/com.ibm.as400.access.TunnelProxyServer

Such URL is not always possible or practical. With custom URL additional query parameters can be added for servlet filters preprocessing such as API token keys, or custom servlet path.

---

Simple example creating AS400 proxy service running within web server such as Tomcat or Wildfly etc.
Additionally, new modern servlet asynchronous processing is available with Executors and tasks.

```Java
@WebServlet(urlPatterns = {"/tunnel"}, asyncSupported = true)
public class TunnelServlet extends HttpServlet {
	
	private PSTunnelController controller;
	
	public void init(ServletConfig config) {
		super.init(config);		
		controller = new PSTunnelController(new ProxyServer());
	}

	void handle(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
		resp.setContentType("application/octet-stream");
		final ServletInputStream inStream = req.getInputStream();
		final ServletOutputStream outStream = resp.getOutputStream();
		controller.runInputStream(inStream, outStream);
		outStream.flush();
	}

	@Override
	public void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
		handle(req, resp);
	}

	@Override
	public void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
		handle(req, resp);
	}

}
```
---
Client example with custom URL

```Java
String proxy = "https://localhost/service.proxy/tunnel?key=1126e94d-a2f0-4c02-86ca-fac023843071";
AS400 system = new AS400("ibm_server", "demo", "demo", proxy);
system.setProxyServer(proxy);

```

----

## Code changes

 - Changed Classes in __com.ibm.as400.access__ 

    - PxClientConnectionAdapter.java
        Changed to use java.net.URI for parsing proxyServer instead of manual parsing.
        openTunnel method changed to use java.net.URI, if custom path not specified, use default as is in original.

    - PSTunnelController.java
        Class changed to public so that it can be used inside custom servlet. 