### PR TITLE
Handle null value when calling ProgramCallDocument.getIntValue()

### DIFF
--- a/src/main/java/com/ibm/as400/data/PcmlDocument.java
+++ b/src/main/java/com/ibm/as400/data/PcmlDocument.java
@@ -518,6 +518,10 @@ class PcmlDocument extends PcmlDocRoot
         {
             return ((Number) value).intValue();
         }
+        else if (value == null)
+        {
+            throw new PcmlException(DAMRI.INPUT_VALUE_NOT_SET, new Object[] {name});
+        }
         else
         {
             throw new PcmlException(DAMRI.STRING_OR_NUMBER, new Object[] {value.getClass().getName(), name} );


### PR DESCRIPTION
When calling `getIntValue()` on a `ProgramCallDocument` where the underlying value is `null`, it currently ends up NPE'ing when the underlying code calls `value.getClass()` when trying to throw the `PcmlException`. An example:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Object.getClass()" because "value" is null
	at com.ibm.as400.data.PcmlDocument.getIntValue(PcmlDocument.java:523)
	at com.ibm.as400.data.PcmlDocument.getIntValue(PcmlDocument.java:503)
	at com.ibm.as400.data.ProgramCallDocument.getIntValue(ProgramCallDocument.java:667)
...
```

Seems like the pattern in other places is to either return `null` directly (not an option here), or to throw an exception with a different message. I decided to go with the latter. Let me know if you would rather handle this another way. Anyway, this makes sure the real exception isn't lost when trying to send it, so the user will have more accurate information if they run into this condition.